### PR TITLE
[Feature] Add the number of killed enemies to info object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+# IDE
+.vscode
+.idea
+
 #
 # Python
 #

--- a/gym_super_mario_bros/_roms/decode_target.py
+++ b/gym_super_mario_bros/_roms/decode_target.py
@@ -1,7 +1,8 @@
 """A method to decode target values for a ROM stage environment."""
+from typing import Optional, Tuple
 
 
-def decode_target(target, lost_levels):
+def decode_target(target: Optional[Tuple[int, int]], lost_levels: bool) -> Optional[Tuple[Optional[int], Optional[int], Optional[int]]]:
     """
     Return the target area for target world and target stage.
 

--- a/gym_super_mario_bros/_roms/rom_path.py
+++ b/gym_super_mario_bros/_roms/rom_path.py
@@ -1,7 +1,6 @@
 """A method to load a ROM path."""
 import os
 
-
 # a dictionary mapping ROM paths first by lost levels, then by ROM hack mode
 _ROM_PATHS = {
     # the dictionary of lost level ROM paths
@@ -19,7 +18,7 @@ _ROM_PATHS = {
 }
 
 
-def rom_path(lost_levels, rom_mode):
+def rom_path(lost_levels: bool, rom_mode: str) -> str:
     """
     Return the ROM filename for a game and ROM mode.
 

--- a/gym_super_mario_bros/smb_env.py
+++ b/gym_super_mario_bros/smb_env.py
@@ -22,7 +22,9 @@ _ENEMY_TYPE_ADDRESSES: List[int] = [0x0016, 0x0017, 0x0018, 0x0019, 0x001A]
 _STAGE_OVER_ENEMIES: np.ndarray = np.array([0x2D, 0x31])
 
 # RAM addresses for enemy status on the screen
-_ENEMY_STATUS_ADDRESSES = [0x001E, 0x001F, 0x0020, 0x0021, 0x0022]
+# https://datacrystal.romhacking.net/wiki/Super_Mario_Bros.:RAM_map
+_ENEMY_STATUS_ADDRESSES: List[int] = [0x001E, 0x001F, 0x0020, 0x0021, 0x0022]
+_ENEMY_KILLED_STATUS: List[int] = [0x04, 0x20, 0x22, 0x23, 0x84]
 
 
 class SuperMarioBrosEnv(NESEnv):
@@ -59,6 +61,7 @@ class SuperMarioBrosEnv(NESEnv):
         self._x_position_last = 0
         # setup a variable to keep track of the number of killed enemies
         self._kill_count = 0
+        self._prev_enemy_status = [0] * len(_ENEMY_STATUS_ADDRESSES)
         # reset the emulator
         self.reset()
         # skip the start screen
@@ -208,8 +211,14 @@ class SuperMarioBrosEnv(NESEnv):
         return self.ram[0x000e]
 
     @property
-    def _kill(self) -> int:
-        pass
+    def _kills(self) -> int:
+        """Return the number of killed enemies."""
+        current_enemy_status = [self.ram[address] for address in _ENEMY_STATUS_ADDRESSES]
+        for i in range(len(_ENEMY_STATUS_ADDRESSES)):
+            if self._prev_enemy_status[i] == 0 and current_enemy_status[i] in _ENEMY_KILLED_STATUS:
+                self._kill_count += 1
+        self._prev_enemy_status = current_enemy_status
+        return self._kill_count
 
     @property
     def _is_dying(self) -> bool:
@@ -366,6 +375,8 @@ class SuperMarioBrosEnv(NESEnv):
         """Handle and RAM hacking before a reset occurs."""
         self._time_last = 0
         self._x_position_last = 0
+        self._kill_count = 0
+        self._prev_enemy_status = [0] * len(_ENEMY_STATUS_ADDRESSES)
 
     def _did_reset(self) -> None:
         """Handle any RAM hacking after a reset occurs."""
@@ -421,6 +432,7 @@ class SuperMarioBrosEnv(NESEnv):
             world=self._world,
             x_pos=self._x_position,
             y_pos=self._y_position,
+            kills=self._kills
         )
 
 

--- a/gym_super_mario_bros/smb_env.py
+++ b/gym_super_mario_bros/smb_env.py
@@ -1,25 +1,25 @@
 """An OpenAI Gym environment for Super Mario Bros. and Lost Levels."""
 from collections import defaultdict
-from typing import Final, DefaultDict, Optional, Union, Tuple, List
+from typing import DefaultDict, Optional, Union, Tuple, List
 from nes_py import NESEnv
 import numpy as np
 from ._roms import decode_target
 from ._roms import rom_path
 
 # create a dictionary mapping value of status register to string names
-_STATUS_MAP: Final[DefaultDict] = defaultdict(lambda: 'fireball', {0: 'small', 1: 'tall'})
+_STATUS_MAP: DefaultDict = defaultdict(lambda: 'fireball', {0: 'small', 1: 'tall'})
 
 # a set of state values indicating that Mario is "busy"
-_BUSY_STATES: Final[List[int]] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x07]
+_BUSY_STATES: List[int] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x07]
 
 # RAM addresses for enemy types on the screen
-_ENEMY_TYPE_ADDRESSES: Final[List[int]] = [0x0016, 0x0017, 0x0018, 0x0019, 0x001A]
+_ENEMY_TYPE_ADDRESSES: List[int] = [0x0016, 0x0017, 0x0018, 0x0019, 0x001A]
 
 # enemies whose context indicate that a stage change will occur (opposed to an
 # enemy that implies a stage change wont occur -- i.e., a vine)
 # Bowser = 0x2D
 # Flagpole = 0x31
-_STAGE_OVER_ENEMIES: Final[np.ndarray] = np.array([0x2D, 0x31])
+_STAGE_OVER_ENEMIES: np.ndarray = np.array([0x2D, 0x31])
 
 
 class SuperMarioBrosEnv(NESEnv):

--- a/gym_super_mario_bros/smb_env.py
+++ b/gym_super_mario_bros/smb_env.py
@@ -21,6 +21,9 @@ _ENEMY_TYPE_ADDRESSES: List[int] = [0x0016, 0x0017, 0x0018, 0x0019, 0x001A]
 # Flagpole = 0x31
 _STAGE_OVER_ENEMIES: np.ndarray = np.array([0x2D, 0x31])
 
+# RAM addresses for enemy status on the screen
+_ENEMY_STATUS_ADDRESSES = [0x001E, 0x001F, 0x0020, 0x0021, 0x0022]
+
 
 class SuperMarioBrosEnv(NESEnv):
     """An environment for playing Super Mario Bros with OpenAI Gym."""
@@ -54,6 +57,8 @@ class SuperMarioBrosEnv(NESEnv):
         self._time_last = 0
         # setup a variable to keep track of the last frames x position
         self._x_position_last = 0
+        # setup a variable to keep track of the number of killed enemies
+        self._kill_count = 0
         # reset the emulator
         self.reset()
         # skip the start screen
@@ -201,6 +206,10 @@ class SuperMarioBrosEnv(NESEnv):
 
         """
         return self.ram[0x000e]
+
+    @property
+    def _kill(self) -> int:
+        pass
 
     @property
     def _is_dying(self) -> bool:

--- a/gym_super_mario_bros/smb_env.py
+++ b/gym_super_mario_bros/smb_env.py
@@ -1,37 +1,34 @@
 """An OpenAI Gym environment for Super Mario Bros. and Lost Levels."""
 from collections import defaultdict
+from typing import Final, DefaultDict, Optional, Union, Tuple, List
 from nes_py import NESEnv
 import numpy as np
 from ._roms import decode_target
 from ._roms import rom_path
 
-
 # create a dictionary mapping value of status register to string names
-_STATUS_MAP = defaultdict(lambda: 'fireball', {0:'small', 1: 'tall'})
-
+_STATUS_MAP: Final[DefaultDict] = defaultdict(lambda: 'fireball', {0: 'small', 1: 'tall'})
 
 # a set of state values indicating that Mario is "busy"
-_BUSY_STATES = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x07]
-
+_BUSY_STATES: Final[List[int]] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x07]
 
 # RAM addresses for enemy types on the screen
-_ENEMY_TYPE_ADDRESSES = [0x0016, 0x0017, 0x0018, 0x0019, 0x001A]
-
+_ENEMY_TYPE_ADDRESSES: Final[List[int]] = [0x0016, 0x0017, 0x0018, 0x0019, 0x001A]
 
 # enemies whose context indicate that a stage change will occur (opposed to an
 # enemy that implies a stage change wont occur -- i.e., a vine)
 # Bowser = 0x2D
 # Flagpole = 0x31
-_STAGE_OVER_ENEMIES = np.array([0x2D, 0x31])
+_STAGE_OVER_ENEMIES: Final[np.ndarray] = np.array([0x2D, 0x31])
 
 
 class SuperMarioBrosEnv(NESEnv):
     """An environment for playing Super Mario Bros with OpenAI Gym."""
 
     # the legal range of rewards for each step
-    reward_range = (-15, 15)
+    reward_range: Tuple[int, int] = (-15, 15)
 
-    def __init__(self, rom_mode='vanilla', lost_levels=False, target=None):
+    def __init__(self, rom_mode: str = 'vanilla', lost_levels: bool = False, target: Optional[Tuple[int, int]] = None):
         """
         Initialize a new Super Mario Bros environment.
 
@@ -65,13 +62,13 @@ class SuperMarioBrosEnv(NESEnv):
         self._backup()
 
     @property
-    def is_single_stage_env(self):
+    def is_single_stage_env(self) -> bool:
         """Return True if this environment is a stage environment."""
         return self._target_world is not None and self._target_area is not None
 
     # MARK: Memory access
 
-    def _read_mem_range(self, address, length):
+    def _read_mem_range(self, address: int, length: int) -> int:
         """
         Read a range of bytes where each byte is a 10's place figure.
 
@@ -93,56 +90,56 @@ class SuperMarioBrosEnv(NESEnv):
         return int(''.join(map(str, self.ram[address:address + length])))
 
     @property
-    def _level(self):
+    def _level(self) -> int:
         """Return the level of the game."""
         return self.ram[0x075f] * 4 + self.ram[0x075c]
 
     @property
-    def _world(self):
+    def _world(self) -> int:
         """Return the current world (1 to 8)."""
         return self.ram[0x075f] + 1
 
     @property
-    def _stage(self):
+    def _stage(self) -> int:
         """Return the current stage (1 to 4)."""
         return self.ram[0x075c] + 1
 
     @property
-    def _area(self):
+    def _area(self) -> int:
         """Return the current area number (1 to 5)."""
         return self.ram[0x0760] + 1
 
     @property
-    def _score(self):
+    def _score(self) -> int:
         """Return the current player score (0 to 999990)."""
         # score is represented as a figure with 6 10's places
         return self._read_mem_range(0x07de, 6)
 
     @property
-    def _time(self):
+    def _time(self) -> int:
         """Return the time left (0 to 999)."""
         # time is represented as a figure with 3 10's places
         return self._read_mem_range(0x07f8, 3)
 
     @property
-    def _coins(self):
+    def _coins(self) -> int:
         """Return the number of coins collected (0 to 99)."""
         # coins are represented as a figure with 2 10's places
         return self._read_mem_range(0x07ed, 2)
 
     @property
-    def _life(self):
+    def _life(self) -> int:
         """Return the number of remaining lives."""
         return self.ram[0x075a]
 
     @property
-    def _x_position(self):
+    def _x_position(self) -> int:
         """Return the current horizontal position."""
         # add the current page 0x6d to the current x
         return self.ram[0x6d] * 0x100 + self.ram[0x86]
 
     @property
-    def _left_x_position(self):
+    def _left_x_position(self) -> np.ndarray:
         """Return the number of pixels from the left of the screen."""
         # TODO: resolve RuntimeWarning: overflow encountered in ubyte_scalars
         # subtract the left x position 0x071c from the current x 0x86
@@ -150,12 +147,12 @@ class SuperMarioBrosEnv(NESEnv):
         return np.uint8(int(self.ram[0x86]) - int(self.ram[0x071c])) % 256
 
     @property
-    def _y_pixel(self):
+    def _y_pixel(self) -> int:
         """Return the current vertical position."""
         return self.ram[0x03b8]
 
     @property
-    def _y_viewport(self):
+    def _y_viewport(self) -> int:
         """
         Return the current y viewport.
 
@@ -169,7 +166,7 @@ class SuperMarioBrosEnv(NESEnv):
         return self.ram[0x00b5]
 
     @property
-    def _y_position(self):
+    def _y_position(self) -> int:
         """Return the current vertical position."""
         # check if Mario is above the viewport (the score board area)
         if self._y_viewport < 1:
@@ -179,12 +176,12 @@ class SuperMarioBrosEnv(NESEnv):
         return 255 - self._y_pixel
 
     @property
-    def _player_status(self):
+    def _player_status(self) -> str:
         """Return the player status as a string."""
         return _STATUS_MAP[self.ram[0x0756]]
 
     @property
-    def _player_state(self):
+    def _player_state(self) -> int:
         """
         Return the current player state.
 
@@ -206,29 +203,29 @@ class SuperMarioBrosEnv(NESEnv):
         return self.ram[0x000e]
 
     @property
-    def _is_dying(self):
+    def _is_dying(self) -> bool:
         """Return True if Mario is in dying animation, False otherwise."""
         return self._player_state == 0x0b or self._y_viewport > 1
 
     @property
-    def _is_dead(self):
+    def _is_dead(self) -> bool:
         """Return True if Mario is dead, False otherwise."""
         return self._player_state == 0x06
 
     @property
-    def _is_game_over(self):
+    def _is_game_over(self) -> bool:
         """Return True if the game has ended, False otherwise."""
         # the life counter will get set to 255 (0xff) when there are no lives
         # left. It goes 2, 1, 0 for the 3 lives of the game
         return self._life == 0xff
 
     @property
-    def _is_busy(self):
+    def _is_busy(self) -> bool:
         """Return boolean whether Mario is busy with in-game garbage."""
         return self._player_state in _BUSY_STATES
 
     @property
-    def _is_world_over(self):
+    def _is_world_over(self) -> bool:
         """Return a boolean determining if the world is over."""
         # 0x0770 contains GamePlay mode:
         # 0 => Demo
@@ -237,7 +234,7 @@ class SuperMarioBrosEnv(NESEnv):
         return self.ram[0x0770] == 2
 
     @property
-    def _is_stage_over(self):
+    def _is_stage_over(self) -> bool:
         """Return a boolean determining if the level is over."""
         # iterate over the memory addresses that hold enemy types
         for address in _ENEMY_TYPE_ADDRESSES:
@@ -251,35 +248,35 @@ class SuperMarioBrosEnv(NESEnv):
         return False
 
     @property
-    def _flag_get(self):
+    def _flag_get(self) -> bool:
         """Return a boolean determining if the agent reached a flag."""
         return self._is_world_over or self._is_stage_over
 
     # MARK: RAM Hacks
 
-    def _write_stage(self):
+    def _write_stage(self) -> None:
         """Write the stage data to RAM to overwrite loading the next stage."""
         self.ram[0x075f] = self._target_world - 1
         self.ram[0x075c] = self._target_stage - 1
         self.ram[0x0760] = self._target_area - 1
 
-    def _runout_prelevel_timer(self):
+    def _runout_prelevel_timer(self) -> None:
         """Force the pre-level timer to 0 to skip frames during a death."""
         self.ram[0x07A0] = 0
 
-    def _skip_change_area(self):
+    def _skip_change_area(self) -> None:
         """Skip change area animations by by running down timers."""
         change_area_timer = self.ram[0x06DE]
-        if change_area_timer > 1 and change_area_timer < 255:
+        if 1 < change_area_timer < 255:
             self.ram[0x06DE] = 1
 
-    def _skip_occupied_states(self):
+    def _skip_occupied_states(self) -> None:
         """Skip occupied states by running out a timer and skipping frames."""
         while self._is_busy or self._is_world_over:
             self._runout_prelevel_timer()
             self._frame_advance(0)
 
-    def _skip_start_screen(self):
+    def _skip_start_screen(self) -> None:
         """Press and release start to skip the start screen."""
         # press and release the start button
         self._frame_advance(8)
@@ -302,7 +299,7 @@ class SuperMarioBrosEnv(NESEnv):
             self._frame_advance(8)
             self._frame_advance(0)
 
-    def _skip_end_of_world(self):
+    def _skip_end_of_world(self) -> None:
         """Skip the cutscene that plays at the end of a world."""
         if self._is_world_over:
             # get the current game time to reference
@@ -312,7 +309,7 @@ class SuperMarioBrosEnv(NESEnv):
                 # frame advance with NOP
                 self._frame_advance(0)
 
-    def _kill_mario(self):
+    def _kill_mario(self) -> None:
         """Skip a death animation by forcing Mario to death."""
         # force Mario's state to dead
         self.ram[0x000e] = 0x06
@@ -322,7 +319,7 @@ class SuperMarioBrosEnv(NESEnv):
     # MARK: Reward Function
 
     @property
-    def _x_reward(self):
+    def _x_reward(self) -> int:
         """Return the reward based on left right movement between steps."""
         _reward = self._x_position - self._x_position_last
         self._x_position_last = self._x_position
@@ -335,7 +332,7 @@ class SuperMarioBrosEnv(NESEnv):
         return _reward
 
     @property
-    def _time_penalty(self):
+    def _time_penalty(self) -> int:
         """Return the reward for the in-game clock ticking."""
         _reward = self._time - self._time_last
         self._time_last = self._time
@@ -347,7 +344,7 @@ class SuperMarioBrosEnv(NESEnv):
         return _reward
 
     @property
-    def _death_penalty(self):
+    def _death_penalty(self) -> int:
         """Return the reward earned by dying."""
         if self._is_dying or self._is_dead:
             return -25
@@ -356,17 +353,17 @@ class SuperMarioBrosEnv(NESEnv):
 
     # MARK: nes-py API calls
 
-    def _will_reset(self):
+    def _will_reset(self) -> None:
         """Handle and RAM hacking before a reset occurs."""
         self._time_last = 0
         self._x_position_last = 0
 
-    def _did_reset(self):
+    def _did_reset(self) -> None:
         """Handle any RAM hacking after a reset occurs."""
         self._time_last = self._time
         self._x_position_last = self._x_position
 
-    def _did_step(self, done):
+    def _did_step(self, done: bool) -> None:
         """
         Handle any RAM hacking after a step occurs.
 
@@ -392,17 +389,17 @@ class SuperMarioBrosEnv(NESEnv):
         # how many lives the player has left
         self._skip_occupied_states()
 
-    def _get_reward(self):
+    def _get_reward(self) -> int:
         """Return the reward after a step occurs."""
         return self._x_reward + self._time_penalty + self._death_penalty
 
-    def _get_done(self):
+    def _get_done(self) -> bool:
         """Return True if the episode is over, False otherwise."""
         if self.is_single_stage_env:
             return self._is_dying or self._is_dead or self._flag_get
         return self._is_game_over
 
-    def _get_info(self):
+    def _get_info(self) -> dict[str, Union[int, np.ndarray]]:
         """Return the info after a step occurs"""
         return dict(
             coins=self._coins,

--- a/gym_super_mario_bros/tests/test_registration.py
+++ b/gym_super_mario_bros/tests/test_registration.py
@@ -21,6 +21,8 @@ class ShouldMakeEnv:
     time = 400
     # the x position of Mario
     x_pos = 40
+    # the number of killed enemies
+    kills = 0
     # the environments ID
     env_id = None
     # the random seed to apply
@@ -40,6 +42,7 @@ class ShouldMakeEnv:
         self.assertEqual(self.stage, i['stage'])
         self.assertEqual(self.time, i['time'])
         self.assertEqual(self.x_pos, i['x_pos'])
+        self.assertEqual(self.kills, i['kills'])
         env.close()
 
     def test(self):

--- a/gym_super_mario_bros/tests/test_smv_env.py
+++ b/gym_super_mario_bros/tests/test_smv_env.py
@@ -67,6 +67,7 @@ class ShouldStepGameEnv(TestCase):
         self.assertEqual(1, i['stage'])
         self.assertEqual(400, i['time'])
         self.assertEqual(40, i['x_pos'])
+        self.assertEqual(0, i['kills'])
         env.close()
 
 
@@ -87,4 +88,5 @@ class ShouldStepStageEnv(TestCase):
         self.assertEqual(2, i['stage'])
         self.assertEqual(400, i['time'])
         self.assertEqual(40, i['x_pos'])
+        self.assertEqual(0, i['kills'])
         env.close()


### PR DESCRIPTION
### Description

This PR add the number of killed enemies into `info` object.
For example, mario kills 3 goomba, then `info["kills"] = 3`.

### Pros and Cons

- Pros
  - This feature can keep track of the number of killed enemies, for analyze log or play. 
- Cons
  - To keep track of this, use 5 length list, so speed will be a very little slower.

### Notes

This PR is based on #103 .

This PR is not need  and not important for this `gym-super-mario-bros` !
So, If you feel that this PR is not important for gym-super-mario-bros, please close this :)


### Type of change

Please select all relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] MGMT (non-breaking change to deployment, CI, etc.

### Checklist

- [x] My code follows the [style guidelines of this project](https://github.com/google/styleguide/blob/gh-pages/pyguide.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
