### PR TITLE
Allow random stages to sample from a subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,24 @@ example, to use the standard ROM with random stage selection use
 `SuperMarioBrosRandomStages-v0`. To seed the random stage selection use the
 `seed` method of the env, i.e., `env.seed(1)`, before any calls to `reset`.
 
+In addition to randomly selecting any of the 32 original stages, a subset of
+user-defined stages can be specified to limit the random choice of stages to a
+specific subset. For example, the stage selector could be limited to only
+sample castle stages, water levels, underground, and more.
+
+To specify a subset of stages to randomly sample from, create a list of each
+stage to allow to be sampled and pass that list to the `gym.make()` function.
+For example:
+
+```python
+import gym
+
+gym.make('SuperMarioBrosRandomStages-v0', stages=['1-4', '2-4', '3-4', '4-4'])
+```
+
+The example above will sample a random stage from 1-4, 2-4, 3-4, and 4-4 upon
+every call to `reset`.
+
 ## Step
 
 Info about the rewards and info returned by the `step` method.

--- a/gym_super_mario_bros/smb_random_stages_env.py
+++ b/gym_super_mario_bros/smb_random_stages_env.py
@@ -20,12 +20,13 @@ class SuperMarioBrosRandomStagesEnv(gym.Env):
     # action space is a bitmap of button press values for the 8 NES buttons
     action_space = SuperMarioBrosEnv.action_space
 
-    def __init__(self, rom_mode='vanilla'):
+    def __init__(self, rom_mode='vanilla', stages=[]):
         """
         Initialize a new Super Mario Bros environment.
 
         Args:
             rom_mode (str): the ROM mode to use when loading ROMs from disk
+            stages (list): select stages at random from a specific subset
 
         Returns:
             None
@@ -51,11 +52,19 @@ class SuperMarioBrosRandomStagesEnv(gym.Env):
         self.env = self.envs[0][0]
         # create a placeholder for the image viewer to render the screen
         self.viewer = None
+        # create a placeholder for the subset of stages to choose
+        self.stages = stages
 
     def _select_random_level(self):
         """Select a random level to use."""
-        world = self.np_random.randint(1, 9) - 1
-        stage = self.np_random.randint(1, 5) - 1
+        if len(self.stages) > 0:
+            level = self.np_random.choice(self.stages)
+            world, stage = level.split('-')
+            world = int(world) - 1
+            stage = int(stage) - 1
+        else:
+            world = self.np_random.randint(1, 9) - 1
+            stage = self.np_random.randint(1, 5) - 1
         self.env = self.envs[world][stage]
 
     def seed(self, seed=None):

--- a/gym_super_mario_bros/tests/test_registration.py
+++ b/gym_super_mario_bros/tests/test_registration.py
@@ -25,9 +25,14 @@ class ShouldMakeEnv:
     env_id = None
     # the random seed to apply
     seed = None
+    # the subset of stages to sample from
+    stages = None
 
-    def _test_env(self, env_id):
-        env = make(env_id)
+    def _test_env(self, env_id, stages):
+        if stages is not None:
+            env = make(env_id)
+        else:
+            env = make(env_id)
         if self.seed is not None:
             env.seed(self.seed)
         env.reset()
@@ -44,10 +49,10 @@ class ShouldMakeEnv:
 
     def test(self):
         if isinstance(self.env_id, str):
-            self._test_env(self.env_id)
+            self._test_env(self.env_id, self.stages)
         elif isinstance(self.env_id, list):
             for env_id in self.env_id:
-                self._test_env(env_id)
+                self._test_env(env_id, self.stages)
 
 
 class ShouldMakeSuperMarioBros(ShouldMakeEnv, TestCase):
@@ -393,3 +398,18 @@ class ShouldMakeSuperMarioBros_8_4(ShouldMakeEnv, TestCase):
     stage = 4
     # the environments ID
     env_id = ['SuperMarioBros-8-4-v{}'.format(v) for v in range(4)]
+
+
+class ShouldMakeSuperMarioBrosRandomStagesSubset(ShouldMakeEnv, TestCase):
+    # the random number seed for this environment
+    seed = 1
+    # the amount of time left
+    time = 300
+    # the current world
+    world = 2
+    # the current stage
+    stage = 4
+    # the stages to sample from
+    stages = ['1-4', '2-4', '3-4', '4-4']
+    # the environments ID for all versions of Super Mario Bros
+    env_id = ['SuperMarioBrosRandomStages-v{}'.format(v) for v in range(4)]


### PR DESCRIPTION
### Description

Random stage selection allows more diverse sampling and exploration for agents, though the wide variety of stages in Super Mario Bros. can be challenging for agents to learn. Specifying a subset of stages to randomly sample allows the user to hand-select similar levels for agents to have more diverse observations, while still being focused enough to learn the mechanics of the environments in question.

For example, several of the castle levels have identical layouts but feature slightly different hazards. Allowing the agent to learn on different castle environments can help it be more generic while still having a reasonable chance of completing the level.

### Type of change

Please select all relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] MGMT (non-breaking change to deployment, CI, etc.

### Checklist

- [x] My code follows the [style guidelines of this project](https://github.com/google/styleguide/blob/gh-pages/pyguide.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
