### PR TITLE
Typecast np.bool to bool

### DIFF
--- a/gym_super_mario_bros/smb_env.py
+++ b/gym_super_mario_bros/smb_env.py
@@ -220,7 +220,7 @@ class SuperMarioBrosEnv(NESEnv):
         """Return True if the game has ended, False otherwise."""
         # the life counter will get set to 255 (0xff) when there are no lives
         # left. It goes 2, 1, 0 for the 3 lives of the game
-        return self._life == 0xff
+        return bool(self._life == 0xff)
 
     @property
     def _is_busy(self):


### PR DESCRIPTION
### Description

This changes the done signal to work with the latest Gym 0.25 API, which only allows type `bool` for done signal, and not `np.bool`. 

### Type of change

Please select all relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] MGMT (non-breaking change to deployment, CI, etc.

### Checklist

- [x] My code follows the [style guidelines of this project](https://github.com/google/styleguide/blob/gh-pages/pyguide.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
