### PR TITLE
newer version of gym requires rewards to be float

### DIFF
--- a/gym_super_mario_bros/smb_env.py
+++ b/gym_super_mario_bros/smb_env.py
@@ -394,7 +394,7 @@ class SuperMarioBrosEnv(NESEnv):
 
     def _get_reward(self):
         """Return the reward after a step occurs."""
-        return self._x_reward + self._time_penalty + self._death_penalty
+        return float(self._x_reward + self._time_penalty + self._death_penalty)
 
     def _get_done(self):
         """Return True if the episode is over, False otherwise."""


### PR DESCRIPTION
### Description

Newer versions of `gym>=0.20.0` requires reward returned by `step()` to be `float`. The new `passive_env_checker.py` checks if the environment complies with this or not. This error could not be avoided with writing custom wrappers that converts the original `int` reward to `float`. 

Error log:
```
  ...
  File "/home/ubuntu/.pyenv/versions/3.8.8/lib/python3.8/site-packages/gym/utils/passive_env_checker.py", line 278, in passive_env_step_check
    assert isinstance(
AssertionError: The reward returned by `step()` must be a float
```

### Type of change

Please select all relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] MGMT (non-breaking change to deployment, CI, etc.

### Checklist

- [x] My code follows the [style guidelines of this project](https://github.com/google/styleguide/blob/gh-pages/pyguide.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
