### PR TITLE
Fixed SuperMarioBrosRandomStagesEnv.render method

### DIFF
--- a/gym_super_mario_bros/smb_random_stages_env.py
+++ b/gym_super_mario_bros/smb_random_stages_env.py
@@ -166,7 +166,7 @@ class SuperMarioBrosRandomStagesEnv(gym.Env):
             a numpy array if mode is 'rgb_array', None otherwise
 
         """
-        return SuperMarioBrosEnv.render(self, mode=mode)
+        return SuperMarioBrosEnv.render(self.env, mode=mode)
 
     def get_keys_to_action(self):
         """Return the dictionary of keyboard keys to actions."""


### PR DESCRIPTION
### Description

The `render` method of `SuperMarioBrosRandomStagesEnv` was broken. It was passing `self` instead of `self.env` when calling an underlying environment method, resulting the following error:

```
>>> env = gym_super_mario_bros.SuperMarioBrosRandomStagesEnv()
>>> env.render()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.11/site-packages/gym_super_mario_bros/smb_random_stages_env.py", line 169, in render
    return SuperMarioBrosEnv.render(self, mode=mode)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/nes_py/nes_env.py", line 375, in render
    caption = self._rom_path.split('/')[-1]
                     ^^^^^^^^^^^^^^
  AttributeError: 'SuperMarioBrosRandomStagesEnv' object has no attribute '_rom_path'
```

### Type of change

Bug fix (non-breaking change which fixes an issue)

