### PR TITLE
[codex] Add Mario task metadata and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ with external time truncation, which returns `truncated=True`.
 **NOTE:** remove calls to `render` in training code for a nontrivial
 speedup.
 
+### Task Metadata
+
+`gym_super_mario_bros` exposes lightweight task metadata for curriculum,
+conditioning, and evaluation-matrix code without constructing ROM-backed
+environments:
+
+```python
+import gym_super_mario_bros
+
+tasks = gym_super_mario_bros.all_tasks(single_stage=True)
+env_ids = gym_super_mario_bros.task_ids(game_family='smb1')
+task = gym_super_mario_bros.task_for_env_id('SuperMarioBros-4-2-v0')
+```
+
+Each `MarioTask` includes the environment ID, canonical task ID, game family,
+ROM mode, world/stage, public world label, split flags, and alias metadata for
+separator-free SMB1 IDs such as `SuperMarioBros1-1-v0`.
+
 ### Command Line
 
 `gym_super_mario_bros` features a command line interface for playing
@@ -188,24 +206,43 @@ death penalties are then added when the underlying game exposes reliable RAM
 counters for that title.
 
 The reward is clipped into the range _(-15, 15)_.
+The `info` dictionary also includes `reward_components`,
+`reward_total_unclipped`, and `reward_total_clipped` so training code can log or
+choose alternate reward transforms without recomputing RAM-dependent shaping.
 
 ### `info` dictionary
 
 The `info` dictionary returned by the `step` method contains the following
 keys:
 
-| Key        | Type   | Description
-|:-----------|:-------|:------------------------------------------------------|
-| `coins   ` | `int`  | The number of collected coins
-| `flag_get` | `bool` | True if Mario reached a flag or ax
-| `life`     | `int`  | The number of lives left, i.e., _{3, 2, 1}_
-| `score`    | `int`  | The cumulative in-game score
-| `stage`    | `int`  | The current stage, i.e., _{1, ..., 4}_
-| `status`   | `str`  | Mario's status, i.e., _{'small', 'tall', 'fireball'}_
-| `time`     | `int`  | The time left on the clock
-| `world`    | `int`  | The current world, i.e., _{1, ..., 8}_
-| `x_pos`    | `int`  | Mario's _x_ position in the stage (from the left)
-| `y_pos`    | `int`  | Mario's _y_ position in the stage (from the bottom)
+| Key | Type | Description |
+|:----|:-----|:------------|
+| `coins` | `int` | The number of collected coins where available |
+| `flag_get` | `bool` | True if Mario reached a flag, ax, or stage-complete state |
+| `life` | `int` | The title-specific displayed life count |
+| `score` | `int` | The cumulative in-game score where available |
+| `stage` | `int` | The current stage |
+| `status` | `str` | Mario's title-specific powerup status |
+| `time` | `int` | The time left on the clock where available |
+| `world` | `int` | The current world |
+| `x_pos` | `int` | Mario's horizontal position where available |
+| `y_pos` | `int` | Mario's vertical position where available |
+| `clear` | `bool` | Cross-game completion flag for the active stage/task |
+| `death` | `bool` | Cross-game death/life-loss flag |
+| `game` | `str` | Normalized game identifier such as `smb1` or `smb3` |
+| `game_family` | `str` | Grouping key for task suites and evaluation matrices |
+| `progress` | `int` | Cross-game progress metric used by the reward function |
+| `progress_max` | `int` | Best progress reached during the current attempt |
+| `rom_mode` | `str` | ROM mode, currently `vanilla` for registered environments |
+| `single_stage` | `bool` | True for single-stage registered tasks |
+| `task_id` | `str` | Canonical task ID suitable for task conditioning |
+| `target_world` | `int` or `None` | Configured target world for single-stage tasks |
+| `target_stage` | `int` or `None` | Configured target stage for single-stage tasks |
+| `timeout` | `bool` | Reserved cross-game timeout flag; external Gymnasium `TimeLimit` still sets `truncated=True` |
+| `world_label` | `str` | Public world label, including Lost Levels bonus worlds |
+| `reward_components` | `dict` | Per-step shaped reward terms before clipping |
+| `reward_total_unclipped` | `float` | Per-step shaped reward before `reward_range` clipping |
+| `reward_total_clipped` | `float` | Per-step shaped reward after `reward_range` clipping |
 
 Newer SMB2 USA and SMB3 environments include additional game-specific keys
 such as raw transition state, health, lives, map position, powerup timers,

--- a/gym_super_mario_bros/__init__.py
+++ b/gym_super_mario_bros/__init__.py
@@ -2,6 +2,10 @@
 from .smb_env import SuperMarioBrosEnv
 from .smb2_env import SuperMarioBros2Env
 from .smb3_env import SuperMarioBros3Env
+from .tasks import MarioTask
+from .tasks import all_tasks
+from .tasks import task_for_env_id
+from .tasks import task_ids
 from ._registration import make
 
 
@@ -11,4 +15,8 @@ __all__ = [
     'SuperMarioBrosEnv',
     'SuperMarioBros2Env',
     'SuperMarioBros3Env',
+    'MarioTask',
+    'all_tasks',
+    'task_for_env_id',
+    'task_ids',
 ]

--- a/gym_super_mario_bros/smb2_env.py
+++ b/gym_super_mario_bros/smb2_env.py
@@ -1,6 +1,7 @@
 """A Gymnasium environment for Super Mario Bros. 2 (USA)."""
 from nes_py import NESEnv
 from ._roms import smb2_rom_path
+from .tasks import task_for_config
 
 
 _CHARACTER_MAP = {
@@ -94,6 +95,8 @@ class SuperMarioBros2Env(NESEnv):
         """
         rom = smb2_rom_path()
         super(SuperMarioBros2Env, self).__init__(rom, render_mode=render_mode)
+        self._rom_mode = 'vanilla'
+        self._rom_version = 0
         target = _decode_smb2_target(target)
         self._target_world, self._target_stage, self._target_level = target
         self._position_origin = (0, 0)
@@ -102,6 +105,9 @@ class SuperMarioBros2Env(NESEnv):
         self._cherries_last = 0
         self._health_last = 0
         self._completion_rewarded = False
+        self._last_reward_components = {}
+        self._last_reward_unclipped = 0.0
+        self._last_reward_clipped = 0.0
         self.reset()
         self._skip_start_screen()
         self._backup()
@@ -110,6 +116,21 @@ class SuperMarioBros2Env(NESEnv):
     def is_single_stage_env(self):
         """Return True if this environment is a stage environment."""
         return self._target_level is not None
+
+    @property
+    def _task(self):
+        """Return metadata for the current configured task."""
+        world = None
+        stage = None
+        if self.is_single_stage_env:
+            world = self._target_world
+            stage = self._target_stage
+        return task_for_config(
+            'smb2_usa',
+            self._rom_version,
+            world=world,
+            stage=stage,
+        )
 
     # MARK: Memory access
 
@@ -355,6 +376,61 @@ class SuperMarioBros2Env(NESEnv):
             return 50
         return 0
 
+    def _clip_reward_value(self, reward):
+        """Return reward clamped to the public reward range."""
+        return max(self.reward_range[0], min(self.reward_range[1], reward))
+
+    def _store_reward_components(self, components):
+        """Store the last per-step reward diagnostics."""
+        self._last_reward_components = {
+            key: float(value)
+            for key, value in components.items()
+        }
+        self._last_reward_unclipped = float(sum(self._last_reward_components.values()))
+        self._last_reward_clipped = float(
+            self._clip_reward_value(self._last_reward_unclipped)
+        )
+
+    def _reset_reward_components(self):
+        """Reset per-step reward diagnostics."""
+        self._last_reward_components = dict(
+            progress=0.0,
+            collectibles=0.0,
+            health=0.0,
+            completion=0.0,
+            death=0.0,
+        )
+        self._last_reward_unclipped = 0.0
+        self._last_reward_clipped = 0.0
+
+    def _reward_info(self):
+        """Return reward diagnostics for the info dictionary."""
+        return dict(
+            reward_components=dict(self._last_reward_components),
+            reward_total_unclipped=self._last_reward_unclipped,
+            reward_total_clipped=self._last_reward_clipped,
+        )
+
+    def _normalized_info(self):
+        """Return cross-game metrics for training and evaluation code."""
+        task = self._task
+        death = self._is_dying or self._is_dead
+        return dict(
+            clear=self._is_level_complete,
+            death=death,
+            game=task.game,
+            game_family=task.game_family,
+            progress=self._position_progress,
+            progress_max=self._position_progress_max,
+            rom_mode=self._rom_mode,
+            single_stage=self.is_single_stage_env,
+            task_id=task.task_id,
+            target_stage=self._target_stage,
+            target_world=self._target_world,
+            timeout=False,
+            world_label=str(self._world),
+        )
+
     # MARK: nes-py API calls
 
     def _will_reset(self):
@@ -365,6 +441,7 @@ class SuperMarioBros2Env(NESEnv):
         self._cherries_last = 0
         self._health_last = 0
         self._completion_rewarded = False
+        self._reset_reward_components()
 
     def _did_reset(self):
         """Handle any RAM hacking after a reset occurs."""
@@ -374,16 +451,20 @@ class SuperMarioBros2Env(NESEnv):
         self._cherries_last = self._cherries
         self._health_last = self._health
         self._completion_rewarded = False
+        self._reset_reward_components()
 
     def _get_reward(self):
         """Return the reward after a step occurs."""
-        return (
-            self._progress_reward +
-            self._collectible_reward +
-            self._health_reward +
-            self._completion_reward +
-            self._death_penalty
+        self._store_reward_components(
+            dict(
+                progress=self._progress_reward,
+                collectibles=self._collectible_reward,
+                health=self._health_reward,
+                completion=self._completion_reward,
+                death=self._death_penalty,
+            )
         )
+        return self._last_reward_unclipped
 
     def _get_terminated(self):
         """Return True if the episode is over, False otherwise."""
@@ -393,7 +474,7 @@ class SuperMarioBros2Env(NESEnv):
 
     def _get_info(self):
         """Return the info after a step occurs."""
-        return dict(
+        info = dict(
             character=self._character,
             character_id=self._read_mem(0x008f),
             character_status=self._character_status,
@@ -424,6 +505,9 @@ class SuperMarioBros2Env(NESEnv):
             y_pos=self._y_position,
             y_screen=self._y_screen,
         )
+        info.update(self._normalized_info())
+        info.update(self._reward_info())
+        return info
 
 
 # explicitly define the outward facing API of this module

--- a/gym_super_mario_bros/smb3_env.py
+++ b/gym_super_mario_bros/smb3_env.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from nes_py import NESEnv
 
 from ._roms import smb3_rom_path
+from .tasks import task_for_config
 
 
 _STATUS_MAP = defaultdict(
@@ -74,6 +75,8 @@ class SuperMarioBros3Env(NESEnv):
         """
         rom = smb3_rom_path()
         super(SuperMarioBros3Env, self).__init__(rom, render_mode=render_mode)
+        self._rom_mode = 'vanilla'
+        self._rom_version = 0
         self._target_world, self._target_stage = _decode_smb3_target(target)
         self._current_world = 1
         self._current_stage = 1
@@ -85,6 +88,9 @@ class SuperMarioBros3Env(NESEnv):
         self._score_last = 0
         self._status_last = 0
         self._completion_rewarded = False
+        self._last_reward_components = {}
+        self._last_reward_unclipped = 0.0
+        self._last_reward_clipped = 0.0
         self.reset()
         self._skip_start_screen()
         self._backup()
@@ -93,6 +99,21 @@ class SuperMarioBros3Env(NESEnv):
     def is_single_stage_env(self):
         """Return True if this environment is a stage environment."""
         return self._target_world is not None
+
+    @property
+    def _task(self):
+        """Return metadata for the current configured task."""
+        world = None
+        stage = None
+        if self.is_single_stage_env:
+            world = self._target_world
+            stage = self._target_stage
+        return task_for_config(
+            'smb3',
+            self._rom_version,
+            world=world,
+            stage=stage,
+        )
 
     # MARK: Memory access
 
@@ -418,6 +439,62 @@ class SuperMarioBros3Env(NESEnv):
             return 50
         return 0
 
+    def _clip_reward_value(self, reward):
+        """Return reward clamped to the public reward range."""
+        return max(self.reward_range[0], min(self.reward_range[1], reward))
+
+    def _store_reward_components(self, components):
+        """Store the last per-step reward diagnostics."""
+        self._last_reward_components = {
+            key: float(value)
+            for key, value in components.items()
+        }
+        self._last_reward_unclipped = float(sum(self._last_reward_components.values()))
+        self._last_reward_clipped = float(
+            self._clip_reward_value(self._last_reward_unclipped)
+        )
+
+    def _reset_reward_components(self):
+        """Reset per-step reward diagnostics."""
+        self._last_reward_components = dict(
+            progress=0.0,
+            time=0.0,
+            score=0.0,
+            powerup=0.0,
+            completion=0.0,
+            death=0.0,
+        )
+        self._last_reward_unclipped = 0.0
+        self._last_reward_clipped = 0.0
+
+    def _reward_info(self):
+        """Return reward diagnostics for the info dictionary."""
+        return dict(
+            reward_components=dict(self._last_reward_components),
+            reward_total_unclipped=self._last_reward_unclipped,
+            reward_total_clipped=self._last_reward_clipped,
+        )
+
+    def _normalized_info(self):
+        """Return cross-game metrics for training and evaluation code."""
+        task = self._task
+        death = self._is_dying or self._is_game_over
+        return dict(
+            clear=self._flag_get,
+            death=death,
+            game=task.game,
+            game_family=task.game_family,
+            progress=self._x_position,
+            progress_max=self._x_position_max,
+            rom_mode=self._rom_mode,
+            single_stage=self.is_single_stage_env,
+            task_id=task.task_id,
+            target_stage=self._target_stage,
+            target_world=self._target_world,
+            timeout=False,
+            world_label=str(self._world),
+        )
+
     # MARK: nes-py API calls
 
     def _will_reset(self):
@@ -430,6 +507,7 @@ class SuperMarioBros3Env(NESEnv):
         self._score_last = 0
         self._status_last = 0
         self._completion_rewarded = False
+        self._reset_reward_components()
 
     def _did_reset(self):
         """Handle RAM bookkeeping after a reset occurs."""
@@ -441,17 +519,21 @@ class SuperMarioBros3Env(NESEnv):
         self._score_last = self._score
         self._status_last = self._powerup_level
         self._completion_rewarded = False
+        self._reset_reward_components()
 
     def _get_reward(self):
         """Return the reward after a step occurs."""
-        return (
-            self._progress_reward +
-            self._time_penalty +
-            self._score_reward +
-            self._powerup_reward +
-            self._completion_reward +
-            self._death_penalty
+        self._store_reward_components(
+            dict(
+                progress=self._progress_reward,
+                time=self._time_penalty,
+                score=self._score_reward,
+                powerup=self._powerup_reward,
+                completion=self._completion_reward,
+                death=self._death_penalty,
+            )
         )
+        return self._last_reward_unclipped
 
     def _get_terminated(self):
         """Return True if the episode is over, False otherwise."""
@@ -461,7 +543,7 @@ class SuperMarioBros3Env(NESEnv):
 
     def _get_info(self):
         """Return the info after a step occurs."""
-        return dict(
+        info = dict(
             card_selection=self._card_selection,
             flag_get=self._flag_get,
             flight_timer=self._flight_timer,
@@ -493,6 +575,9 @@ class SuperMarioBros3Env(NESEnv):
             y_pos=self._y_position,
             y_screen=self._y_screen,
         )
+        info.update(self._normalized_info())
+        info.update(self._reward_info())
+        return info
 
 
 # explicitly define the outward facing API of this module

--- a/gym_super_mario_bros/smb_env.py
+++ b/gym_super_mario_bros/smb_env.py
@@ -4,6 +4,7 @@ from nes_py import NESEnv
 from ._roms import decode_target
 from ._roms import smb1_rom_path
 from ._roms import smb2jp_rom_path
+from .tasks import task_for_config
 
 
 # create a dictionary mapping value of status register to string names
@@ -56,6 +57,9 @@ class SuperMarioBrosEnv(NESEnv):
         rom = smb2jp_rom_path() if lost_levels else smb1_rom_path()
         # initialize the super object with the ROM path
         super(SuperMarioBrosEnv, self).__init__(rom, render_mode=render_mode)
+        self._rom_mode = 'vanilla'
+        self._rom_version = 0
+        self._lost_levels = lost_levels
         # set the target world, stage, and area variables
         target = decode_target(target, lost_levels)
         self._target_world, self._target_stage, self._target_area = target
@@ -67,6 +71,9 @@ class SuperMarioBrosEnv(NESEnv):
         self._coins_last = 0
         self._status_last = 0
         self._completion_rewarded = False
+        self._last_reward_components = {}
+        self._last_reward_unclipped = 0.0
+        self._last_reward_clipped = 0.0
         # reset the emulator
         self.reset()
         # skip the start screen
@@ -78,6 +85,35 @@ class SuperMarioBrosEnv(NESEnv):
     def is_single_stage_env(self):
         """Return True if this environment is a stage environment."""
         return self._target_world is not None and self._target_area is not None
+
+    @property
+    def _game(self):
+        """Return the normalized game identifier."""
+        if self._lost_levels:
+            return 'lost_levels'
+        return 'smb1'
+
+    @property
+    def _world_label(self):
+        """Return the public world label for task metadata."""
+        if self._lost_levels and self._world >= 10:
+            return chr(ord('A') + self._world - 10)
+        return str(self._world)
+
+    @property
+    def _task(self):
+        """Return metadata for the current configured task."""
+        world = None
+        stage = None
+        if self.is_single_stage_env:
+            world = self._target_world
+            stage = self._target_stage
+        return task_for_config(
+            self._game,
+            self._rom_version,
+            world=world,
+            stage=stage,
+        )
 
     # MARK: Memory access
 
@@ -419,6 +455,64 @@ class SuperMarioBrosEnv(NESEnv):
             return 50
         return 0
 
+    def _clip_reward_value(self, reward):
+        """Return reward clamped to the public reward range."""
+        return max(self.reward_range[0], min(self.reward_range[1], reward))
+
+    def _store_reward_components(self, components):
+        """Store the last per-step reward diagnostics."""
+        self._last_reward_components = {
+            key: float(value)
+            for key, value in components.items()
+        }
+        self._last_reward_unclipped = float(sum(self._last_reward_components.values()))
+        self._last_reward_clipped = float(
+            self._clip_reward_value(self._last_reward_unclipped)
+        )
+
+    def _reset_reward_components(self):
+        """Reset per-step reward diagnostics."""
+        self._last_reward_components = dict(
+            progress=0.0,
+            time=0.0,
+            score=0.0,
+            coins=0.0,
+            powerup=0.0,
+            completion=0.0,
+            death=0.0,
+        )
+        self._last_reward_unclipped = 0.0
+        self._last_reward_clipped = 0.0
+
+    def _reward_info(self):
+        """Return reward diagnostics for the info dictionary."""
+        return dict(
+            reward_components=dict(self._last_reward_components),
+            reward_total_unclipped=self._last_reward_unclipped,
+            reward_total_clipped=self._last_reward_clipped,
+        )
+
+    def _normalized_info(self):
+        """Return cross-game metrics for training and evaluation code."""
+        task = self._task
+        death = self._is_dying or self._is_dead
+        return dict(
+            clear=self._flag_get,
+            death=death,
+            game=task.game,
+            game_family=task.game_family,
+            lives=self._life,
+            progress=self._x_position,
+            progress_max=self._x_position_max,
+            rom_mode=self._rom_mode,
+            single_stage=self.is_single_stage_env,
+            task_id=task.task_id,
+            target_stage=self._target_stage,
+            target_world=self._target_world,
+            timeout=False,
+            world_label=self._world_label,
+        )
+
     # MARK: nes-py API calls
 
     def _will_reset(self):
@@ -429,6 +523,7 @@ class SuperMarioBrosEnv(NESEnv):
         self._coins_last = 0
         self._status_last = 0
         self._completion_rewarded = False
+        self._reset_reward_components()
 
     def _did_reset(self):
         """Handle any RAM hacking after a reset occurs."""
@@ -438,6 +533,7 @@ class SuperMarioBrosEnv(NESEnv):
         self._coins_last = self._coins
         self._status_last = self._powerup_level
         self._completion_rewarded = False
+        self._reset_reward_components()
 
     def _did_step(self, done):
         """
@@ -467,15 +563,18 @@ class SuperMarioBrosEnv(NESEnv):
 
     def _get_reward(self):
         """Return the reward after a step occurs."""
-        return (
-            self._progress_reward +
-            self._time_penalty +
-            self._score_reward +
-            self._coin_reward +
-            self._powerup_reward +
-            self._completion_reward +
-            self._death_penalty
+        self._store_reward_components(
+            dict(
+                progress=self._progress_reward,
+                time=self._time_penalty,
+                score=self._score_reward,
+                coins=self._coin_reward,
+                powerup=self._powerup_reward,
+                completion=self._completion_reward,
+                death=self._death_penalty,
+            )
         )
+        return self._last_reward_unclipped
 
     def _get_terminated(self):
         """Return True if the episode is over, False otherwise."""
@@ -485,7 +584,7 @@ class SuperMarioBrosEnv(NESEnv):
 
     def _get_info(self):
         """Return the info after a step occurs"""
-        return dict(
+        info = dict(
             area=self._area,
             coins=self._coins,
             enemy_types=self._enemy_types,
@@ -512,6 +611,9 @@ class SuperMarioBrosEnv(NESEnv):
             y_pos=self._y_position,
             y_viewport=self._y_viewport,
         )
+        info.update(self._normalized_info())
+        info.update(self._reward_info())
+        return info
 
 
 # explicitly define the outward facing API of this module

--- a/gym_super_mario_bros/tasks.py
+++ b/gym_super_mario_bros/tasks.py
@@ -1,0 +1,267 @@
+"""Task metadata for registered Super Mario Bros. environments."""
+from dataclasses import dataclass
+
+
+SMB1_ROM_MODES = ('vanilla',)
+LOST_LEVELS_ROM_MODES = ('vanilla',)
+SMB2_USA_STAGES_PER_WORLD = (3, 3, 3, 3, 3, 3, 2)
+SMB3_VALIDATED_STAGES = ((1, 1),)
+
+
+@dataclass(frozen=True)
+class MarioTask:
+    """A queryable description of one registered Mario task."""
+
+    env_id: str
+    game: str
+    game_family: str
+    version: int
+    rom_mode: str
+    world: int | None = None
+    stage: int | None = None
+    world_label: str | None = None
+    single_stage: bool = False
+    alias_of: str | None = None
+    train_split: bool = True
+    eval_split: bool = True
+    validated: bool = True
+
+    @property
+    def task_id(self):
+        """Return the stable task identifier for conditioning/evaluation."""
+        return self.alias_of or self.env_id
+
+    def to_dict(self):
+        """Return this task as a plain dictionary."""
+        return dict(
+            env_id=self.env_id,
+            task_id=self.task_id,
+            game=self.game,
+            game_family=self.game_family,
+            version=self.version,
+            rom_mode=self.rom_mode,
+            world=self.world,
+            stage=self.stage,
+            world_label=self.world_label,
+            single_stage=self.single_stage,
+            alias_of=self.alias_of,
+            train_split=self.train_split,
+            eval_split=self.eval_split,
+            validated=self.validated,
+        )
+
+
+def _lost_levels_world_label(world):
+    """Return the public world label for a Lost Levels world number."""
+    if world <= 9:
+        return str(world)
+    return chr(ord('A') + world - 10)
+
+
+def _build_tasks():
+    """Build the package task inventory from the registered env surface."""
+    tasks = []
+
+    for version, rom_mode in enumerate(SMB1_ROM_MODES):
+        tasks.append(MarioTask(
+            env_id='SuperMarioBros-v{}'.format(version),
+            game='smb1',
+            game_family='smb1',
+            version=version,
+            rom_mode=rom_mode,
+        ))
+
+        for world in range(1, 9):
+            for stage in range(1, 5):
+                canonical_env_id = 'SuperMarioBros-{}-{}-v{}'.format(
+                    world,
+                    stage,
+                    version,
+                )
+                tasks.append(MarioTask(
+                    env_id=canonical_env_id,
+                    game='smb1',
+                    game_family='smb1',
+                    version=version,
+                    rom_mode=rom_mode,
+                    world=world,
+                    stage=stage,
+                    world_label=str(world),
+                    single_stage=True,
+                ))
+                tasks.append(MarioTask(
+                    env_id='SuperMarioBros{}-{}-v{}'.format(
+                        world,
+                        stage,
+                        version,
+                    ),
+                    game='smb1',
+                    game_family='smb1',
+                    version=version,
+                    rom_mode=rom_mode,
+                    world=world,
+                    stage=stage,
+                    world_label=str(world),
+                    single_stage=True,
+                    alias_of=canonical_env_id,
+                ))
+
+    for version, rom_mode in enumerate(LOST_LEVELS_ROM_MODES):
+        tasks.append(MarioTask(
+            env_id='SuperMarioBros2-v{}'.format(version),
+            game='lost_levels',
+            game_family='lost_levels',
+            version=version,
+            rom_mode=rom_mode,
+        ))
+        for world in range(1, 14):
+            world_label = _lost_levels_world_label(world)
+            for stage in range(1, 5):
+                tasks.append(MarioTask(
+                    env_id='SuperMarioBros2-{}-{}-v{}'.format(
+                        world_label,
+                        stage,
+                        version,
+                    ),
+                    game='lost_levels',
+                    game_family='lost_levels',
+                    version=version,
+                    rom_mode=rom_mode,
+                    world=world,
+                    stage=stage,
+                    world_label=world_label,
+                    single_stage=True,
+                ))
+
+    tasks.append(MarioTask(
+        env_id='SuperMarioBros2USA-v0',
+        game='smb2_usa',
+        game_family='smb2_usa',
+        version=0,
+        rom_mode='vanilla',
+    ))
+    for world, stage_count in enumerate(SMB2_USA_STAGES_PER_WORLD, start=1):
+        for stage in range(1, stage_count + 1):
+            tasks.append(MarioTask(
+                env_id='SuperMarioBros2USA-{}-{}-v0'.format(world, stage),
+                game='smb2_usa',
+                game_family='smb2_usa',
+                version=0,
+                rom_mode='vanilla',
+                world=world,
+                stage=stage,
+                world_label=str(world),
+                single_stage=True,
+            ))
+
+    tasks.append(MarioTask(
+        env_id='SuperMarioBros3-v0',
+        game='smb3',
+        game_family='smb3',
+        version=0,
+        rom_mode='vanilla',
+    ))
+    for world, stage in SMB3_VALIDATED_STAGES:
+        tasks.append(MarioTask(
+            env_id='SuperMarioBros3-{}-{}-v0'.format(world, stage),
+            game='smb3',
+            game_family='smb3',
+            version=0,
+            rom_mode='vanilla',
+            world=world,
+            stage=stage,
+            world_label=str(world),
+            single_stage=True,
+        ))
+
+    return tuple(tasks)
+
+
+TASKS = _build_tasks()
+_TASKS_BY_ENV_ID = {task.env_id: task for task in TASKS}
+
+
+def all_tasks(
+    *,
+    include_aliases=False,
+    game_family=None,
+    rom_mode=None,
+    single_stage=None,
+    split=None,
+    validated=None,
+):
+    """
+    Return registered task metadata filtered for training/evaluation code.
+
+    Args:
+        include_aliases (bool): include alias environment IDs when True
+        game_family (str): optional game-family filter
+        rom_mode (str): optional ROM-mode filter
+        single_stage (bool): optional single-stage/full-game filter
+        split (str): optional "train" or "eval" split filter
+        validated (bool): optional validated-coverage filter
+
+    Returns:
+        tuple[MarioTask]: matching tasks
+
+    """
+    tasks = TASKS
+    if not include_aliases:
+        tasks = tuple(task for task in tasks if task.alias_of is None)
+    if game_family is not None:
+        tasks = tuple(task for task in tasks if task.game_family == game_family)
+    if rom_mode is not None:
+        tasks = tuple(task for task in tasks if task.rom_mode == rom_mode)
+    if single_stage is not None:
+        tasks = tuple(task for task in tasks if task.single_stage == single_stage)
+    if split == 'train':
+        tasks = tuple(task for task in tasks if task.train_split)
+    elif split == 'eval':
+        tasks = tuple(task for task in tasks if task.eval_split)
+    elif split is not None:
+        raise ValueError("split must be one of: 'train', 'eval'")
+    if validated is not None:
+        tasks = tuple(task for task in tasks if task.validated == validated)
+    return tasks
+
+
+def task_ids(**filters):
+    """Return matching task environment IDs for the given filters."""
+    return tuple(task.env_id for task in all_tasks(**filters))
+
+
+def task_for_env_id(env_id):
+    """Return task metadata for a registered environment ID."""
+    try:
+        return _TASKS_BY_ENV_ID[env_id]
+    except KeyError as exc:
+        raise KeyError('unknown Mario environment ID: {}'.format(env_id)) from exc
+
+
+def task_for_config(game, version, world=None, stage=None):
+    """Return task metadata for a game/version/target tuple."""
+    for task in TASKS:
+        if task.alias_of is not None:
+            continue
+        if task.game != game:
+            continue
+        if task.version != version:
+            continue
+        if task.world != world or task.stage != stage:
+            continue
+        return task
+    raise KeyError('no Mario task matches the requested configuration')
+
+
+__all__ = [
+    'LOST_LEVELS_ROM_MODES',
+    'MarioTask',
+    'SMB1_ROM_MODES',
+    'SMB2_USA_STAGES_PER_WORLD',
+    'SMB3_VALIDATED_STAGES',
+    'TASKS',
+    'all_tasks',
+    'task_for_config',
+    'task_for_env_id',
+    'task_ids',
+]

--- a/gym_super_mario_bros/tests/test_registration.py
+++ b/gym_super_mario_bros/tests/test_registration.py
@@ -62,6 +62,10 @@ class ShouldExposePackageApi(TestCase):
                 'SuperMarioBrosEnv',
                 'SuperMarioBros2Env',
                 'SuperMarioBros3Env',
+                'MarioTask',
+                'all_tasks',
+                'task_for_env_id',
+                'task_ids',
             ],
             gym_super_mario_bros.__all__,
         )

--- a/gym_super_mario_bros/tests/test_smb2_env.py
+++ b/gym_super_mario_bros/tests/test_smb2_env.py
@@ -131,6 +131,25 @@ class ShouldStepSuperMarioBros2UsaEnv(TestCase):
             self.assertEqual(1, info['y_page'])
             self.assertEqual(448, info['y_pos'])
             self.assertEqual(192, info['y_screen'])
+            self.assertFalse(info['clear'])
+            self.assertFalse(info['death'])
+            self.assertEqual('smb2_usa', info['game'])
+            self.assertEqual('smb2_usa', info['game_family'])
+            self.assertEqual(0, info['progress'])
+            self.assertEqual(0, info['progress_max'])
+            self.assertEqual('vanilla', info['rom_mode'])
+            self.assertFalse(info['single_stage'])
+            self.assertEqual('SuperMarioBros2USA-v0', info['task_id'])
+            self.assertFalse(info['timeout'])
+            self.assertEqual('1', info['world_label'])
+            self.assertIsNone(info['target_world'])
+            self.assertIsNone(info['target_stage'])
+            self.assertEqual(0.0, info['reward_total_unclipped'])
+            self.assertEqual(0.0, info['reward_total_clipped'])
+            self.assertEqual(
+                {'progress', 'collectibles', 'health', 'completion', 'death'},
+                set(info['reward_components']),
+            )
         finally:
             env.close()
 
@@ -161,6 +180,13 @@ class ShouldStepSuperMarioBros2UsaStageEnv(TestCase):
             self.assertEqual(2, info['stage'])
             self.assertEqual(120, info['x_pos'])
             self.assertEqual(128, info['y_pos'])
+            self.assertFalse(info['clear'])
+            self.assertFalse(info['death'])
+            self.assertEqual('smb2_usa', info['game'])
+            self.assertTrue(info['single_stage'])
+            self.assertEqual('SuperMarioBros2USA-4-2-v0', info['task_id'])
+            self.assertEqual(4, info['target_world'])
+            self.assertEqual(2, info['target_stage'])
         finally:
             env.close()
 
@@ -215,6 +241,22 @@ class ShouldRewardSuperMarioBros2UsaMovement(TestCase):
             env.ram[0x04ec] = 0x03
             self.assertEqual(50, env.unwrapped._completion_reward)
             self.assertEqual(0, env.unwrapped._completion_reward)
+        finally:
+            env.close()
+
+    def test_reward_diagnostics_match_clipped_step_reward(self):
+        env = SuperMarioBros2Env(render_mode='rgb_array')
+        try:
+            env.reset()
+            env.ram[0x0028] = 123
+
+            reward = env.unwrapped._get_reward()
+            info = env.unwrapped._reward_info()
+
+            self.assertEqual(3.0, reward)
+            self.assertEqual(3.0, info['reward_components']['progress'])
+            self.assertEqual(3.0, info['reward_total_unclipped'])
+            self.assertEqual(3.0, info['reward_total_clipped'])
         finally:
             env.close()
 

--- a/gym_super_mario_bros/tests/test_smb3_env.py
+++ b/gym_super_mario_bros/tests/test_smb3_env.py
@@ -108,6 +108,25 @@ class ShouldStepSuperMarioBros3Env(TestCase):
             self.assertEqual(1, info['y_page'])
             self.assertEqual(384, info['y_pos'])
             self.assertEqual(128, info['y_screen'])
+            self.assertFalse(info['clear'])
+            self.assertFalse(info['death'])
+            self.assertEqual('smb3', info['game'])
+            self.assertEqual('smb3', info['game_family'])
+            self.assertEqual(24, info['progress'])
+            self.assertEqual(24, info['progress_max'])
+            self.assertEqual('vanilla', info['rom_mode'])
+            self.assertFalse(info['single_stage'])
+            self.assertEqual('SuperMarioBros3-v0', info['task_id'])
+            self.assertFalse(info['timeout'])
+            self.assertEqual('1', info['world_label'])
+            self.assertIsNone(info['target_world'])
+            self.assertIsNone(info['target_stage'])
+            self.assertEqual(0.0, info['reward_total_unclipped'])
+            self.assertEqual(0.0, info['reward_total_clipped'])
+            self.assertEqual(
+                {'progress', 'time', 'score', 'powerup', 'completion', 'death'},
+                set(info['reward_components']),
+            )
         finally:
             env.close()
 
@@ -139,6 +158,13 @@ class ShouldStepSuperMarioBros3StageEnv(TestCase):
             self.assertEqual(1, info['stage'])
             self.assertEqual(24, info['x_pos'])
             self.assertEqual(384, info['y_pos'])
+            self.assertFalse(info['clear'])
+            self.assertFalse(info['death'])
+            self.assertEqual('smb3', info['game'])
+            self.assertTrue(info['single_stage'])
+            self.assertEqual('SuperMarioBros3-1-1-v0', info['task_id'])
+            self.assertEqual(1, info['target_world'])
+            self.assertEqual(1, info['target_stage'])
         finally:
             env.close()
 
@@ -200,6 +226,22 @@ class ShouldRewardSuperMarioBros3Movement(TestCase):
             env.ram[0x0079] = 0x40
             self.assertEqual(50, env.unwrapped._completion_reward)
             self.assertEqual(0, env.unwrapped._completion_reward)
+        finally:
+            env.close()
+
+    def test_reward_diagnostics_match_clipped_step_reward(self):
+        env = SuperMarioBros3Env(render_mode='rgb_array')
+        try:
+            env.reset()
+            env.ram[0x0090] = 27
+
+            reward = env.unwrapped._get_reward()
+            info = env.unwrapped._reward_info()
+
+            self.assertEqual(3.0, reward)
+            self.assertEqual(3.0, info['reward_components']['progress'])
+            self.assertEqual(3.0, info['reward_total_unclipped'])
+            self.assertEqual(3.0, info['reward_total_clipped'])
         finally:
             env.close()
 

--- a/gym_super_mario_bros/tests/test_smv_env.py
+++ b/gym_super_mario_bros/tests/test_smv_env.py
@@ -102,6 +102,33 @@ class ShouldStepGameEnv(TestCase):
         self.assertEqual(176, i['y_pixel'])
         self.assertEqual(79, i['y_pos'])
         self.assertEqual(1, i['y_viewport'])
+        self.assertFalse(i['clear'])
+        self.assertFalse(i['death'])
+        self.assertEqual('smb1', i['game'])
+        self.assertEqual('smb1', i['game_family'])
+        self.assertEqual(40, i['progress'])
+        self.assertEqual(40, i['progress_max'])
+        self.assertEqual('vanilla', i['rom_mode'])
+        self.assertFalse(i['single_stage'])
+        self.assertEqual('SuperMarioBros-v0', i['task_id'])
+        self.assertFalse(i['timeout'])
+        self.assertEqual('1', i['world_label'])
+        self.assertIsNone(i['target_world'])
+        self.assertIsNone(i['target_stage'])
+        self.assertEqual(0.0, i['reward_total_unclipped'])
+        self.assertEqual(0.0, i['reward_total_clipped'])
+        self.assertEqual(
+            {
+                'progress',
+                'time',
+                'score',
+                'coins',
+                'powerup',
+                'completion',
+                'death',
+            },
+            set(i['reward_components']),
+        )
         env.close()
 
 
@@ -135,6 +162,15 @@ class ShouldStepStageEnv(TestCase):
         self.assertEqual(40, i['x_pos'])
         self.assertEqual(13, i['level'])
         self.assertEqual(40, i['x_pos_max'])
+        self.assertFalse(i['clear'])
+        self.assertFalse(i['death'])
+        self.assertEqual('smb1', i['game'])
+        self.assertEqual(40, i['progress'])
+        self.assertEqual(40, i['progress_max'])
+        self.assertTrue(i['single_stage'])
+        self.assertEqual('SuperMarioBros-4-2-v0', i['task_id'])
+        self.assertEqual(4, i['target_world'])
+        self.assertEqual(2, i['target_stage'])
         env.close()
 
 
@@ -177,5 +213,21 @@ class ShouldRewardSuperMarioBrosObjectives(TestCase):
             env.ram[0x001d] = 3
             self.assertEqual(50, env.unwrapped._completion_reward)
             self.assertEqual(0, env.unwrapped._completion_reward)
+        finally:
+            env.close()
+
+    def test_reward_diagnostics_match_clipped_step_reward(self):
+        env = SuperMarioBrosEnv(render_mode='rgb_array')
+        try:
+            env.reset()
+            env.ram[0x0086] = 43
+
+            reward = env.unwrapped._get_reward()
+            info = env.unwrapped._reward_info()
+
+            self.assertEqual(3.0, reward)
+            self.assertEqual(3.0, info['reward_components']['progress'])
+            self.assertEqual(3.0, info['reward_total_unclipped'])
+            self.assertEqual(3.0, info['reward_total_clipped'])
         finally:
             env.close()

--- a/gym_super_mario_bros/tests/test_tasks.py
+++ b/gym_super_mario_bros/tests/test_tasks.py
@@ -1,0 +1,67 @@
+"""Tests for registered Mario task metadata."""
+from unittest import TestCase
+
+from ..tasks import MarioTask
+from ..tasks import all_tasks
+from ..tasks import task_for_config
+from ..tasks import task_for_env_id
+from ..tasks import task_ids
+
+
+class ShouldExposeRegisteredTaskMetadata(TestCase):
+    """Test task metadata helpers for the current environment surface."""
+
+    def test_task_inventory_matches_registered_env_surface(self):
+        canonical_tasks = all_tasks()
+        all_env_ids = task_ids(include_aliases=True)
+
+        self.assertEqual(109, len(canonical_tasks))
+        self.assertEqual(141, len(all_env_ids))
+        self.assertIn('SuperMarioBros-v0', all_env_ids)
+        self.assertIn('SuperMarioBros1-1-v0', all_env_ids)
+        self.assertIn('SuperMarioBros2-D-4-v0', all_env_ids)
+        self.assertIn('SuperMarioBros2USA-7-2-v0', all_env_ids)
+        self.assertIn('SuperMarioBros3-1-1-v0', all_env_ids)
+        self.assertNotIn('SuperMarioBrosRandomStages-v0', all_env_ids)
+
+    def test_task_lookup_by_env_id(self):
+        task = task_for_env_id('SuperMarioBros2-A-2-v0')
+
+        self.assertIsInstance(task, MarioTask)
+        self.assertEqual('lost_levels', task.game)
+        self.assertEqual(10, task.world)
+        self.assertEqual('A', task.world_label)
+        self.assertEqual(2, task.stage)
+        self.assertTrue(task.single_stage)
+        self.assertEqual(task.env_id, task.task_id)
+
+    def test_aliases_point_to_canonical_task_id(self):
+        task = task_for_env_id('SuperMarioBros1-1-v0')
+
+        self.assertEqual('SuperMarioBros-1-1-v0', task.task_id)
+        self.assertEqual('SuperMarioBros-1-1-v0', task.alias_of)
+
+    def test_config_lookup_returns_canonical_tasks(self):
+        self.assertEqual(
+            'SuperMarioBros-v0',
+            task_for_config('smb1', 0).env_id,
+        )
+        self.assertEqual(
+            'SuperMarioBros-4-2-v0',
+            task_for_config('smb1', 0, world=4, stage=2).env_id,
+        )
+        self.assertEqual(
+            'SuperMarioBros2USA-7-2-v0',
+            task_for_config('smb2_usa', 0, world=7, stage=2).env_id,
+        )
+
+    def test_filters_are_available_for_eval_matrices(self):
+        stage_tasks = all_tasks(single_stage=True)
+        smb3_tasks = all_tasks(game_family='smb3')
+
+        self.assertEqual(105, len(stage_tasks))
+        self.assertEqual(
+            ('SuperMarioBros3-v0', 'SuperMarioBros3-1-1-v0'),
+            tuple(task.env_id for task in smb3_tasks),
+        )
+        self.assertRaises(ValueError, all_tasks, split='unknown')


### PR DESCRIPTION
## Summary

- add a lightweight `MarioTask` metadata API for the currently registered environment surface
- expose normalized cross-game `info` keys for task IDs, progress, clear/death flags, ROM mode, and single-stage targets
- add per-step reward diagnostics with component totals before and after reward-range clipping
- document the task metadata and richer `info` payload

## Notes

This intentionally leaves the existing environment registry unchanged. `SuperMarioBrosRandomStages-*` remains unregistered, and SMB3 support remains limited to the existing validated entries.

## Validation

- `.venv/bin/python -m unittest discover -s . -p 'test*.py'`\n- `git diff --check`