### PR TITLE
[codex] Fix SMB2 and SMB3 RL terminal signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,10 @@ Upcoming major release aligned with the current `pyproject.toml` version.
     `SuperMarioBros2USA-v0` and 20 single-stage
     `SuperMarioBros2USA-<world>-<stage>-v0` environments.
   - Added vanilla Super Mario Bros. 3 support through `SuperMarioBros3-v0`
-    and the validated `SuperMarioBros3-1-1-v0` single-stage environment.
+    and validated World 1 single-stage environments for 1-1, 1-2, 1-4, and
+    1-6.
+  - Added an SMB3 numbered-course matrix helper for curriculum and evaluation
+    code.
   - Enriched SMB1, SMB2 USA, and SMB3 info dictionaries and expanded reward
     shaping beyond raw rightward velocity.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,30 @@
 This changelog is reconstructed from the repository's local tags, README,
 package metadata, and commit history.
 
-## 9.0.0 (Unreleased)
+## 9.1.0 (Unreleased)
 
-Upcoming major release aligned with the current `pyproject.toml` version.
+- Environments:
+  - Expanded validated Super Mario Bros. 3 single-stage entry points from
+    World 1-1 to World 1-1, 1-2, 1-4, and 1-6.
+  - Added `smb3_stage_matrix()` and `SMB3Stage` so curriculum, evaluation,
+    and tooling code can inspect SMB3 numbered-course metadata separately from
+    the registered reset-entry surface.
+  - Exposed the validated SMB3 entries through Gymnasium registration and
+    `MarioTask` task metadata.
+- Compatibility and maintenance:
+  - Raised the `nes-py` dependency floor to `nes-py>=9.0.1` and switched the
+    developer bootstrap requirements to the PyPI release.
+  - Added SMB3 status-bar render regression coverage for the MMC3 timing fix
+    supplied by `nes-py` 9.0.1.
+- Documentation and tests:
+  - Documented the SMB3 stage matrix helper and currently validated SMB3
+    single-stage environments.
+  - Added tests for SMB3 stage metadata, validated reset entry points,
+    registration, and task inventory filters.
+
+## 9.0.0 (2026-06-10)
+
+Major release aligned with the `pyproject.toml` package metadata.
 
 - Breaking changes:
   - Migrated the package from the legacy Gym API to Gymnasium.
@@ -29,10 +50,7 @@ Upcoming major release aligned with the current `pyproject.toml` version.
     `SuperMarioBros2USA-v0` and 20 single-stage
     `SuperMarioBros2USA-<world>-<stage>-v0` environments.
   - Added vanilla Super Mario Bros. 3 support through `SuperMarioBros3-v0`
-    and validated World 1 single-stage environments for 1-1, 1-2, 1-4, and
-    1-6.
-  - Added an SMB3 numbered-course matrix helper for curriculum and evaluation
-    code.
+    and the validated `SuperMarioBros3-1-1-v0` single-stage environment.
   - Enriched SMB1, SMB2 USA, and SMB3 info dictionaries and expanded reward
     shaping beyond raw rightward velocity.
 

--- a/README.md
+++ b/README.md
@@ -100,11 +100,14 @@ import gym_super_mario_bros
 tasks = gym_super_mario_bros.all_tasks(single_stage=True)
 env_ids = gym_super_mario_bros.task_ids(game_family='smb1')
 task = gym_super_mario_bros.task_for_env_id('SuperMarioBros-4-2-v0')
+smb3_stages = gym_super_mario_bros.smb3_stage_matrix()
 ```
 
 Each `MarioTask` includes the environment ID, canonical task ID, game family,
 ROM mode, world/stage, public world label, split flags, and alias metadata for
 separator-free SMB1 IDs such as `SuperMarioBros1-1-v0`.
+The SMB3 stage matrix catalogs the numbered vanilla courses separately from
+the smaller set of validated single-stage reset entry points.
 
 ### Command Line
 
@@ -184,8 +187,13 @@ where `<world>` is a number in {1, 2, 3, 4, 5, 6, 7}. Worlds 1 through 6 have
 stages {1, 2, 3}; world 7 has stages {1, 2}.
 
 Super Mario Bros. 3 uses the vanilla ROM only. Use `SuperMarioBros3-v0` for
-the game, or `SuperMarioBros3-1-1-v0` for the validated World 1-1 single-stage
-entry point.
+the game, or the currently validated single-stage entry points
+`SuperMarioBros3-1-1-v0`, `SuperMarioBros3-1-2-v0`,
+`SuperMarioBros3-1-4-v0`, and `SuperMarioBros3-1-6-v0`.
+
+The helper `gym_super_mario_bros.smb3_stage_matrix()` returns catalog metadata
+for SMB3's numbered courses. Pass `validated=True` to limit the catalog to
+single-stage entries that are registered and smoke-tested.
 
 ## Step
 

--- a/gym_super_mario_bros/__init__.py
+++ b/gym_super_mario_bros/__init__.py
@@ -2,6 +2,8 @@
 from .smb_env import SuperMarioBrosEnv
 from .smb2_env import SuperMarioBros2Env
 from .smb3_env import SuperMarioBros3Env
+from .smb3_stages import SMB3Stage
+from .smb3_stages import smb3_stage_matrix
 from .tasks import MarioTask
 from .tasks import all_tasks
 from .tasks import task_for_env_id
@@ -15,6 +17,8 @@ __all__ = [
     'SuperMarioBrosEnv',
     'SuperMarioBros2Env',
     'SuperMarioBros3Env',
+    'SMB3Stage',
+    'smb3_stage_matrix',
     'MarioTask',
     'all_tasks',
     'task_for_env_id',

--- a/gym_super_mario_bros/_registration.py
+++ b/gym_super_mario_bros/_registration.py
@@ -1,6 +1,8 @@
 """Registration code of Gymnasium environments in this package."""
 import gymnasium as gym
 
+from .smb3_stages import smb3_stage_matrix
+
 
 _MAX_EPISODE_STEPS = 9999999
 _REWARD_THRESHOLD = 9999999
@@ -178,8 +180,9 @@ for world, stage_count in enumerate(_SMB2_USA_STAGES_PER_WORLD, start=1):
         _register_smb2_usa_env(env_id, target=(world, stage))
 
 
-# Super Mario Bros. 3 has a validated vanilla World 1-1 entry point.
-_register_smb3_env('SuperMarioBros3-1-1-v0', target=(1, 1))
+# Super Mario Bros. 3 exposes validated vanilla World 1 entry points.
+for stage in smb3_stage_matrix(validated=True):
+    _register_smb3_env(stage.env_id, target=stage.target)
 
 
 # create an alias to gymnasium.make for ease of access

--- a/gym_super_mario_bros/smb2_env.py
+++ b/gym_super_mario_bros/smb2_env.py
@@ -21,6 +21,14 @@ _LEVEL_TRANSITION_COMPLETE = 0x03
 _LEVEL_TRANSITION_WARP = 0x04
 
 
+def _signed_byte(value):
+    """Return an unsigned byte interpreted as a signed offset."""
+    value = int(value)
+    if value >= 0x80:
+        return value - 0x100
+    return value
+
+
 def _decode_smb2_target(target):
     """
     Return the target world, stage, and linear level index.
@@ -101,6 +109,7 @@ class SuperMarioBros2Env(NESEnv):
         self._target_world, self._target_stage, self._target_level = target
         self._position_origin = (0, 0)
         self._position_progress_max = 0
+        self._lives_start = 0
         self._coins_last = 0
         self._cherries_last = 0
         self._health_last = 0
@@ -236,7 +245,7 @@ class SuperMarioBros2Env(NESEnv):
     @property
     def _y_position(self):
         """Return the current vertical position."""
-        return self._read_mem(0x001e) * 0x100 + self._read_mem(0x0032)
+        return _signed_byte(self._read_mem(0x001e)) * 0x100 + self._read_mem(0x0032)
 
     @property
     def _y_page(self):
@@ -262,7 +271,7 @@ class SuperMarioBros2Env(NESEnv):
     @property
     def _is_dying(self):
         """Return True if the player is in a death transition."""
-        return self._level_transition == _LEVEL_TRANSITION_RESTART
+        return self._level_transition == _LEVEL_TRANSITION_RESTART or self._lost_life
 
     @property
     def _is_dead(self):
@@ -281,6 +290,20 @@ class SuperMarioBros2Env(NESEnv):
             _LEVEL_TRANSITION_COMPLETE,
             _LEVEL_TRANSITION_WARP,
         )
+
+    @property
+    def _lost_life(self):
+        """Return True if the current attempt has consumed a life."""
+        return (
+            self._lives_start > 0 and
+            self._lives != 0xff and
+            self._lives < self._lives_start
+        )
+
+    @property
+    def _left_target_stage(self):
+        """Return True if a single-stage attempt left its target level."""
+        return self.is_single_stage_env and self._level != self._target_level
 
     # MARK: RAM Hacks
 
@@ -323,6 +346,7 @@ class SuperMarioBros2Env(NESEnv):
             self._frame_advance(0)
         self._position_origin = (self._x_position, self._y_position)
         self._position_progress_max = 0
+        self._lives_start = self._lives
         self._coins_last = self._coins
         self._cherries_last = self._cherries
         self._health_last = self._health
@@ -364,6 +388,9 @@ class SuperMarioBros2Env(NESEnv):
     @property
     def _health_reward(self):
         """Return the reward for gaining or losing health."""
+        if self._lost_life:
+            self._health_last = self._health
+            return 0
         _reward = self._health - self._health_last
         self._health_last = self._health
         return _reward * 5
@@ -437,6 +464,7 @@ class SuperMarioBros2Env(NESEnv):
         """Handle and RAM hacking before a reset occurs."""
         self._position_origin = (0, 0)
         self._position_progress_max = 0
+        self._lives_start = 0
         self._coins_last = 0
         self._cherries_last = 0
         self._health_last = 0
@@ -447,11 +475,23 @@ class SuperMarioBros2Env(NESEnv):
         """Handle any RAM hacking after a reset occurs."""
         self._position_origin = (self._x_position, self._y_position)
         self._position_progress_max = 0
+        self._lives_start = self._lives
         self._coins_last = self._coins
         self._cherries_last = self._cherries
         self._health_last = self._health
         self._completion_rewarded = False
         self._reset_reward_components()
+
+    def _did_step(self, done):
+        """Reset full-game reward baselines after a non-terminal life loss."""
+        if done or not self._lost_life:
+            return
+        self._lives_start = self._lives
+        self._position_origin = (self._x_position, self._y_position)
+        self._position_progress_max = 0
+        self._coins_last = self._coins
+        self._cherries_last = self._cherries
+        self._health_last = self._health
 
     def _get_reward(self):
         """Return the reward after a step occurs."""
@@ -469,7 +509,12 @@ class SuperMarioBros2Env(NESEnv):
     def _get_terminated(self):
         """Return True if the episode is over, False otherwise."""
         if self.is_single_stage_env:
-            return self._is_dying or self._is_dead or self._is_level_complete
+            return (
+                self._is_dying or
+                self._is_dead or
+                self._is_level_complete or
+                self._left_target_stage
+            )
         return self._is_game_over
 
     def _get_info(self):

--- a/gym_super_mario_bros/smb3_env.py
+++ b/gym_super_mario_bros/smb3_env.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from nes_py import NESEnv
 
 from ._roms import smb3_rom_path
+from .smb3_stages import SMB3_VALIDATED_STAGES
 from .tasks import task_for_config
 
 
@@ -23,6 +24,36 @@ _STATUS_MAP = defaultdict(
 _MAP_START = (0x40, 0x20)
 _WORLD_1_LEVEL_1_PANEL = (0x20, 0x40)
 _WORLD_1_LEVEL_1_JUNCTION = (0x40, 0x40)
+_MAP_PLAYER_Y = 0x0075
+_MAP_PLAYER_X_HI = 0x0077
+_MAP_PLAYER_X = 0x0079
+_MAP_PLAYER_MOVE = 0x007b
+_MAP_PLAYER_DIRECTION = 0x007d
+_MAP_PLAYER_TILE = 0x00e5
+
+
+_SMB3_STAGE_ENTRY_RECIPES = {
+    (1, 1): dict(
+        start=(0x40, 0x40, 0x00, 0x4a, 0x01),
+        action=16,
+        panel=_WORLD_1_LEVEL_1_PANEL,
+    ),
+    (1, 2): dict(
+        start=(0x20, 0x60, 0x00, 0x47, 0x01),
+        action=128,
+        panel=(0x20, 0x80),
+    ),
+    (1, 4): dict(
+        start=(0x40, 0x80, 0x00, 0x46, 0x04),
+        action=128,
+        panel=(0x40, 0xa0),
+    ),
+    (1, 6): dict(
+        start=(0xa0, 0x60, 0x00, 0xa3, 0x01),
+        action=128,
+        panel=(0xa0, 0x80),
+    ),
+}
 
 
 def _decode_smb3_target(target):
@@ -44,13 +75,14 @@ def _decode_smb3_target(target):
     target_world, target_stage = target
     if not isinstance(target_world, int):
         raise TypeError('target_world must be of type: int')
-    if target_world != 1:
-        raise ValueError('target_world must be 1 for Super Mario Bros. 3')
-
     if not isinstance(target_stage, int):
         raise TypeError('target_stage must be of type: int')
-    if target_stage != 1:
-        raise ValueError('target_stage must be 1 for Super Mario Bros. 3')
+    if (target_world, target_stage) not in SMB3_VALIDATED_STAGES:
+        raise ValueError(
+            'target must be one of: {}'.format(
+                ', '.join('{}-{}'.format(*target) for target in SMB3_VALIDATED_STAGES)
+            )
+        )
 
     return target_world, target_stage
 
@@ -342,6 +374,22 @@ class SuperMarioBros3Env(NESEnv):
         """Enter World 1-1 from the World 1 map start."""
         self._walk_map(128, _WORLD_1_LEVEL_1_JUNCTION)
         self._walk_map(16, _WORLD_1_LEVEL_1_PANEL)
+        self._enter_map_panel()
+        self._current_world = 1
+        self._current_stage = 1
+
+    def _write_map_entry_start(self, recipe):
+        """Place Mario on a map path next to the target panel."""
+        y, x, x_hi, tile, direction = recipe['start']
+        self.ram[_MAP_PLAYER_Y] = y
+        self.ram[_MAP_PLAYER_X_HI] = x_hi
+        self.ram[_MAP_PLAYER_X] = x
+        self.ram[_MAP_PLAYER_MOVE] = 0
+        self.ram[_MAP_PLAYER_DIRECTION] = direction
+        self.ram[_MAP_PLAYER_TILE] = tile
+
+    def _enter_map_panel(self):
+        """Enter the currently selected world-map panel."""
         for _ in range(120):
             self._frame_advance(0)
         self._press_and_release(1)
@@ -352,8 +400,18 @@ class SuperMarioBros3Env(NESEnv):
         for _ in range(180):
             self._frame_advance(0)
         self._entered_level = True
-        self._current_world = 1
-        self._current_stage = 1
+
+    def _enter_target_stage(self):
+        """Enter the configured validated SMB3 stage from the World 1 map."""
+        target = (self._target_world, self._target_stage)
+        recipe = _SMB3_STAGE_ENTRY_RECIPES[target]
+        self._write_map_entry_start(recipe)
+        for _ in range(10):
+            self._frame_advance(0)
+        self._walk_map(recipe['action'], recipe['panel'])
+        self._enter_map_panel()
+        self._current_world = self._target_world
+        self._current_stage = self._target_stage
 
     def _skip_start_screen(self):
         """Skip title and map screens to reach the first playable level."""
@@ -362,7 +420,10 @@ class SuperMarioBros3Env(NESEnv):
         self._advance_until_map_start()
         for _ in range(120):
             self._frame_advance(0)
-        self._enter_world_1_level_1()
+        if self.is_single_stage_env:
+            self._enter_target_stage()
+        else:
+            self._enter_world_1_level_1()
         self._life_start = self._life
         self._life_last = self._life
         self._time_last = self._time

--- a/gym_super_mario_bros/smb3_env.py
+++ b/gym_super_mario_bros/smb3_env.py
@@ -120,6 +120,7 @@ class SuperMarioBros3Env(NESEnv):
         self._score_last = 0
         self._status_last = 0
         self._completion_rewarded = False
+        self._life_loss_pending = False
         self._last_reward_components = {}
         self._last_reward_unclipped = 0.0
         self._last_reward_clipped = 0.0
@@ -342,6 +343,7 @@ class SuperMarioBros3Env(NESEnv):
             self._entered_level and
             self._is_on_map and
             not self._is_dying and
+            not self._life_loss_pending and
             not self._is_game_over
         )
 
@@ -461,6 +463,9 @@ class SuperMarioBros3Env(NESEnv):
     @property
     def _time_penalty(self):
         """Return the reward for the in-game clock ticking."""
+        if not self._is_in_level:
+            self._time_last = self._time
+            return 0
         _reward = self._time - self._time_last
         self._time_last = self._time
         if _reward > 0:
@@ -568,6 +573,7 @@ class SuperMarioBros3Env(NESEnv):
         self._score_last = 0
         self._status_last = 0
         self._completion_rewarded = False
+        self._life_loss_pending = False
         self._reset_reward_components()
 
     def _did_reset(self):
@@ -580,7 +586,22 @@ class SuperMarioBros3Env(NESEnv):
         self._score_last = self._score
         self._status_last = self._powerup_level
         self._completion_rewarded = False
+        self._life_loss_pending = False
         self._reset_reward_components()
+
+    def _did_step(self, done):
+        """Handle non-terminal map returns after a life loss."""
+        if done:
+            return
+        if self._is_in_level:
+            self._life_loss_pending = False
+            return
+        if self._is_dying and not self._is_game_over:
+            self._life_loss_pending = True
+            self._life_start = self._life
+            self._life_last = self._life
+            self._time_last = self._time
+            self._x_position_max = self._x_position
 
     def _get_reward(self):
         """Return the reward after a step occurs."""

--- a/gym_super_mario_bros/smb3_stages.py
+++ b/gym_super_mario_bros/smb3_stages.py
@@ -1,0 +1,74 @@
+"""Stage metadata for Super Mario Bros. 3."""
+from dataclasses import dataclass
+
+
+SMB3_STAGES_PER_WORLD = (6, 5, 9, 6, 9, 10, 9, 2)
+SMB3_VALIDATED_STAGES = ((1, 1), (1, 2), (1, 4), (1, 6))
+
+
+@dataclass(frozen=True)
+class SMB3Stage:
+    """A catalog entry for one numbered Super Mario Bros. 3 course."""
+
+    world: int
+    stage: int
+    validated: bool = False
+
+    @property
+    def env_id(self):
+        """Return the registered-style environment ID for this stage."""
+        return 'SuperMarioBros3-{}-{}-v0'.format(self.world, self.stage)
+
+    @property
+    def target(self):
+        """Return the ``SuperMarioBros3Env`` target tuple for this stage."""
+        return self.world, self.stage
+
+    @property
+    def world_label(self):
+        """Return the public world label."""
+        return str(self.world)
+
+
+def _build_smb3_stage_matrix():
+    """Return catalog entries for SMB3's numbered courses."""
+    validated = set(SMB3_VALIDATED_STAGES)
+    stages = []
+    for world, stage_count in enumerate(SMB3_STAGES_PER_WORLD, start=1):
+        for stage in range(1, stage_count + 1):
+            stages.append(SMB3Stage(
+                world=world,
+                stage=stage,
+                validated=(world, stage) in validated,
+            ))
+    return tuple(stages)
+
+
+SMB3_STAGE_MATRIX = _build_smb3_stage_matrix()
+
+
+def smb3_stage_matrix(*, validated=None):
+    """
+    Return catalog metadata for SMB3 numbered courses.
+
+    Args:
+        validated (bool): optionally filter to stages with validated reset
+            entry recipes.
+
+    Returns:
+        tuple[SMB3Stage]: matching SMB3 stage metadata
+
+    """
+    stages = SMB3_STAGE_MATRIX
+    if validated is not None:
+        stages = tuple(stage for stage in stages if stage.validated == validated)
+    return stages
+
+
+__all__ = [
+    'SMB3Stage',
+    'SMB3_STAGES_PER_WORLD',
+    'SMB3_STAGE_MATRIX',
+    'SMB3_VALIDATED_STAGES',
+    'smb3_stage_matrix',
+]

--- a/gym_super_mario_bros/tasks.py
+++ b/gym_super_mario_bros/tasks.py
@@ -1,11 +1,13 @@
 """Task metadata for registered Super Mario Bros. environments."""
 from dataclasses import dataclass
 
+from .smb3_stages import SMB3_VALIDATED_STAGES
+from .smb3_stages import smb3_stage_matrix
+
 
 SMB1_ROM_MODES = ('vanilla',)
 LOST_LEVELS_ROM_MODES = ('vanilla',)
 SMB2_USA_STAGES_PER_WORLD = (3, 3, 3, 3, 3, 3, 2)
-SMB3_VALIDATED_STAGES = ((1, 1),)
 
 
 @dataclass(frozen=True)
@@ -161,16 +163,16 @@ def _build_tasks():
         version=0,
         rom_mode='vanilla',
     ))
-    for world, stage in SMB3_VALIDATED_STAGES:
+    for smb3_stage in smb3_stage_matrix(validated=True):
         tasks.append(MarioTask(
-            env_id='SuperMarioBros3-{}-{}-v0'.format(world, stage),
+            env_id=smb3_stage.env_id,
             game='smb3',
             game_family='smb3',
             version=0,
             rom_mode='vanilla',
-            world=world,
-            stage=stage,
-            world_label=str(world),
+            world=smb3_stage.world,
+            stage=smb3_stage.stage,
+            world_label=smb3_stage.world_label,
             single_stage=True,
         ))
 

--- a/gym_super_mario_bros/tests/test_registration.py
+++ b/gym_super_mario_bros/tests/test_registration.py
@@ -6,10 +6,10 @@ import gym_super_mario_bros
 
 from .. import _registration
 from .._registration import make
+from ..smb3_stages import SMB3_VALIDATED_STAGES
 
 
 _SMB2_USA_STAGES_PER_WORLD = (3, 3, 3, 3, 3, 3, 2)
-_SMB3_STAGE_IDS = ('SuperMarioBros3-1-1-v0',)
 
 
 def _expected_stage_ids():
@@ -44,7 +44,8 @@ def _expected_smb2_usa_stage_ids():
 
 def _expected_smb3_stage_ids():
     """Return the registered Super Mario Bros. 3 stage IDs."""
-    yield from _SMB3_STAGE_IDS
+    for world, stage in SMB3_VALIDATED_STAGES:
+        yield 'SuperMarioBros3-{}-{}-v0'.format(world, stage)
 
 
 class ShouldExposePackageApi(TestCase):
@@ -62,6 +63,8 @@ class ShouldExposePackageApi(TestCase):
                 'SuperMarioBrosEnv',
                 'SuperMarioBros2Env',
                 'SuperMarioBros3Env',
+                'SMB3Stage',
+                'smb3_stage_matrix',
                 'MarioTask',
                 'all_tasks',
                 'task_for_env_id',
@@ -170,14 +173,14 @@ class ShouldRegisterExpectedGymnasiumEnvs(TestCase):
 
     def test_smb3_stage_ids_are_registered(self):
         stage_ids = list(_expected_smb3_stage_ids())
-        self.assertEqual(1, len(stage_ids))
+        self.assertEqual(4, len(stage_ids))
         for env_id in stage_ids:
             spec = gym.spec(env_id)
             self.assertEqual(
                 'gym_super_mario_bros:SuperMarioBros3Env',
                 spec.entry_point,
             )
-            self.assertEqual({'target': (1, 1)}, spec.kwargs)
+            self.assertIn(spec.kwargs['target'], SMB3_VALIDATED_STAGES)
             self._assert_common_registration_policy(env_id)
 
     def test_removed_variant_ids_are_not_registered(self):

--- a/gym_super_mario_bros/tests/test_smb2_env.py
+++ b/gym_super_mario_bros/tests/test_smb2_env.py
@@ -208,6 +208,21 @@ class ShouldRewardSuperMarioBros2UsaMovement(TestCase):
         finally:
             env.close()
 
+    def test_vertical_page_wrap_does_not_pollute_progress_max(self):
+        env = SuperMarioBros2Env(target=(5, 1), render_mode='rgb_array')
+        try:
+            env.reset()
+            for step in range(96):
+                action = 131 if step % 16 in (8, 9, 10, 11) else 130
+                _, _, terminated, truncated, info = env.step(action)
+                self.assertFalse(terminated)
+                self.assertFalse(truncated)
+
+            self.assertLess(info['progress_max'], 1000)
+            self.assertLess(info['progress'], 1000)
+        finally:
+            env.close()
+
     def test_backtracking_is_not_penalized_by_progress(self):
         env = SuperMarioBros2Env(render_mode='rgb_array')
         try:
@@ -263,6 +278,37 @@ class ShouldRewardSuperMarioBros2UsaMovement(TestCase):
 
 class ShouldTerminateSuperMarioBros2UsaEnv(TestCase):
     """Test death, game-over, and level-complete termination helpers."""
+
+    def test_stage_env_terminates_when_life_loss_restarts_another_level(self):
+        env = SuperMarioBros2Env(target=(7, 2), render_mode='rgb_array')
+        try:
+            env.reset()
+            terminal_step = None
+
+            for step in range(1, 180):
+                _, reward, terminated, truncated, info = env.step(130)
+                if terminated or truncated:
+                    terminal_step = step, reward, terminated, truncated, info
+                    break
+
+            self.assertIsNotNone(terminal_step)
+            step, reward, terminated, truncated, info = terminal_step
+            self.assertEqual(130, step)
+            self.assertEqual(-15, reward)
+            self.assertTrue(terminated)
+            self.assertFalse(truncated)
+            self.assertTrue(info['death'])
+            self.assertFalse(info['clear'])
+            self.assertEqual(2, info['lives'])
+            self.assertEqual(0, info['level'])
+            self.assertEqual(1, info['world'])
+            self.assertEqual(1, info['stage'])
+            self.assertEqual(0.0, info['reward_components']['health'])
+            self.assertEqual(-25.0, info['reward_components']['death'])
+            self.assertEqual(-25.0, info['reward_total_unclipped'])
+            self.assertEqual(-15.0, info['reward_total_clipped'])
+        finally:
+            env.close()
 
     def test_stage_env_terminates_on_death_and_completion(self):
         env = SuperMarioBros2Env(target=(1, 1), render_mode='rgb_array')

--- a/gym_super_mario_bros/tests/test_smb3_env.py
+++ b/gym_super_mario_bros/tests/test_smb3_env.py
@@ -6,13 +6,17 @@ from ..smb3_env import _decode_smb3_target
 
 
 class ShouldDecodeSuperMarioBros3Targets(TestCase):
-    """Test target validation for the validated SMB3 entry point."""
+    """Test target validation for the validated SMB3 entry points."""
 
     def test_none_target(self):
         self.assertEqual((None, None), _decode_smb3_target(None))
 
     def test_world_1_stage_1_target(self):
         self.assertEqual((1, 1), _decode_smb3_target((1, 1)))
+
+    def test_validated_world_1_targets(self):
+        for stage in (2, 4, 6):
+            self.assertEqual((1, stage), _decode_smb3_target((1, stage)))
 
     def test_invalid_target_type(self):
         self.assertRaises(TypeError, _decode_smb3_target, '1-1')
@@ -29,7 +33,9 @@ class ShouldDecodeSuperMarioBros3Targets(TestCase):
 
     def test_invalid_stage_bounds(self):
         self.assertRaises(ValueError, _decode_smb3_target, (1, 0))
-        self.assertRaises(ValueError, _decode_smb3_target, (1, 2))
+        self.assertRaises(ValueError, _decode_smb3_target, (1, 3))
+        self.assertRaises(ValueError, _decode_smb3_target, (1, 5))
+        self.assertRaises(ValueError, _decode_smb3_target, (1, 7))
 
 
 class ShouldStepSuperMarioBros3Env(TestCase):
@@ -167,6 +173,35 @@ class ShouldStepSuperMarioBros3StageEnv(TestCase):
             self.assertEqual(1, info['target_stage'])
         finally:
             env.close()
+
+    def test_validated_world_1_stage_targets(self):
+        for stage in (2, 4, 6):
+            env = SuperMarioBros3Env(target=(1, stage), render_mode='rgb_array')
+            try:
+                self.assertTrue(env.unwrapped.is_single_stage_env)
+                self.assertEqual(1, env.unwrapped._target_world)
+                self.assertEqual(stage, env.unwrapped._target_stage)
+
+                state, reset_info = env.reset()
+                self.assertEqual(env.observation_space.shape, state.shape)
+                self.assertIsInstance(reset_info, dict)
+
+                state, reward, terminated, truncated, info = env.step(0)
+                self.assertEqual(env.observation_space.shape, state.shape)
+                self.assertEqual(0.0, reward)
+                self.assertFalse(terminated)
+                self.assertFalse(truncated)
+                self.assertTrue(info['in_level'])
+                self.assertEqual(1, info['world'])
+                self.assertEqual(stage, info['stage'])
+                self.assertEqual(
+                    'SuperMarioBros3-1-{}-v0'.format(stage),
+                    info['task_id'],
+                )
+                self.assertEqual(1, info['target_world'])
+                self.assertEqual(stage, info['target_stage'])
+            finally:
+                env.close()
 
 
 class ShouldRewardSuperMarioBros3Movement(TestCase):

--- a/gym_super_mario_bros/tests/test_smb3_env.py
+++ b/gym_super_mario_bros/tests/test_smb3_env.py
@@ -204,6 +204,48 @@ class ShouldStepSuperMarioBros3StageEnv(TestCase):
                 env.close()
 
 
+class ShouldRenderSuperMarioBros3StatusBar(TestCase):
+    """Regression coverage for MMC3 status-bar CHR banking in SMB3."""
+
+    def test_world_1_stage_2_status_bar_tiles_are_stable(self):
+        env = SuperMarioBros3Env(target=(1, 2), render_mode='rgb_array')
+        try:
+            env.reset()
+            state, _, _, _, info = env.step(0)
+            self.assertEqual('SuperMarioBros3-1-2-v0', info['task_id'])
+
+            expected_pixels = {
+                (200, 13): (252, 252, 252),
+                (200, 21): (0, 0, 0),
+                (201, 16): (0, 252, 252),
+                (201, 48): (0, 252, 252),
+                (203, 96): (0, 252, 252),
+                (208, 8): (0, 0, 0),
+                (224, 208): (0, 0, 0),
+                (227, 10): (0, 0, 0),
+            }
+            for (y, x), expected in expected_pixels.items():
+                with self.subTest(pixel=(y, x)):
+                    self.assertEqual(expected, tuple(map(int, state[y, x])))
+        finally:
+            env.close()
+
+    def test_status_bar_baseline_stays_fixed_while_stage_scrolls(self):
+        env = SuperMarioBros3Env(render_mode='rgb_array')
+        try:
+            env.reset(seed=17)
+            for step in range(241):
+                state, _, terminated, truncated, _ = env.step(128)
+                self.assertFalse(terminated)
+                self.assertFalse(truncated)
+                if step in (0, 60, 120, 180, 240):
+                    with self.subTest(step=step):
+                        self.assertEqual((0, 0, 0), tuple(map(int, state[227, 10])))
+                        self.assertEqual((0, 0, 0), tuple(map(int, state[224, 10])))
+        finally:
+            env.close()
+
+
 class ShouldRewardSuperMarioBros3Movement(TestCase):
     """Test position progress reward behavior."""
 

--- a/gym_super_mario_bros/tests/test_smb3_env.py
+++ b/gym_super_mario_bros/tests/test_smb3_env.py
@@ -326,6 +326,35 @@ class ShouldRewardSuperMarioBros3Movement(TestCase):
 class ShouldTerminateSuperMarioBros3Env(TestCase):
     """Test stage-return, death, and game-over termination helpers."""
 
+    def test_stage_env_step_returns_positive_clear_reward(self):
+        env = SuperMarioBros3Env(target=(1, 1), render_mode='rgb_array')
+        try:
+            env.reset()
+            env.unwrapped._entered_level = True
+            env.unwrapped._life_start = 4
+            env.unwrapped._life_last = 4
+            env.ram[0x0736] = 4
+            env.ram[0x05ee] = 0
+            env.ram[0x05ef] = 0
+            env.ram[0x05f0] = 0
+            env.ram[0x0075] = 0x20
+            env.ram[0x0079] = 0x40
+
+            _, reward, terminated, truncated, info = env.step(0)
+
+            self.assertTrue(terminated)
+            self.assertFalse(truncated)
+            self.assertEqual(15, reward)
+            self.assertTrue(info['flag_get'])
+            self.assertTrue(info['clear'])
+            self.assertFalse(info['death'])
+            self.assertEqual(0.0, info['reward_components']['time'])
+            self.assertEqual(50.0, info['reward_components']['completion'])
+            self.assertEqual(50.0, info['reward_total_unclipped'])
+            self.assertEqual(15.0, info['reward_total_clipped'])
+        finally:
+            env.close()
+
     def test_stage_env_terminates_on_death_and_completion(self):
         env = SuperMarioBros3Env(target=(1, 1), render_mode='rgb_array')
         try:
@@ -361,5 +390,41 @@ class ShouldTerminateSuperMarioBros3Env(TestCase):
 
             env.ram[0x0736] = 0xff
             self.assertTrue(env.unwrapped._get_terminated())
+        finally:
+            env.close()
+
+    def test_full_env_life_loss_returns_to_map_without_clear_latch(self):
+        env = SuperMarioBros3Env(render_mode='rgb_array')
+        try:
+            env.reset()
+            env.ram[0x00b4] = 0xc0
+            death_step = None
+
+            for _ in range(360):
+                _, reward, terminated, truncated, info = env.step(0)
+                if info['death']:
+                    death_step = reward, terminated, truncated, info
+                    break
+
+            self.assertIsNotNone(death_step)
+            reward, terminated, truncated, info = death_step
+            self.assertEqual(-15, reward)
+            self.assertFalse(terminated)
+            self.assertFalse(truncated)
+            self.assertFalse(info['flag_get'])
+            self.assertFalse(info['clear'])
+            self.assertTrue(info['death'])
+            self.assertFalse(info['in_level'])
+            self.assertEqual(3, info['life'])
+
+            _, reward, terminated, truncated, info = env.step(0)
+            self.assertEqual(0.0, reward)
+            self.assertFalse(terminated)
+            self.assertFalse(truncated)
+            self.assertFalse(info['flag_get'])
+            self.assertFalse(info['clear'])
+            self.assertFalse(info['death'])
+            self.assertFalse(info['in_level'])
+            self.assertEqual(3, info['life'])
         finally:
             env.close()

--- a/gym_super_mario_bros/tests/test_tasks.py
+++ b/gym_super_mario_bros/tests/test_tasks.py
@@ -3,6 +3,9 @@ from unittest import TestCase
 
 from ..tasks import MarioTask
 from ..tasks import all_tasks
+from ..smb3_stages import SMB3_STAGES_PER_WORLD
+from ..smb3_stages import SMB3_VALIDATED_STAGES
+from ..smb3_stages import smb3_stage_matrix
 from ..tasks import task_for_config
 from ..tasks import task_for_env_id
 from ..tasks import task_ids
@@ -15,13 +18,14 @@ class ShouldExposeRegisteredTaskMetadata(TestCase):
         canonical_tasks = all_tasks()
         all_env_ids = task_ids(include_aliases=True)
 
-        self.assertEqual(109, len(canonical_tasks))
-        self.assertEqual(141, len(all_env_ids))
+        self.assertEqual(112, len(canonical_tasks))
+        self.assertEqual(144, len(all_env_ids))
         self.assertIn('SuperMarioBros-v0', all_env_ids)
         self.assertIn('SuperMarioBros1-1-v0', all_env_ids)
         self.assertIn('SuperMarioBros2-D-4-v0', all_env_ids)
         self.assertIn('SuperMarioBros2USA-7-2-v0', all_env_ids)
         self.assertIn('SuperMarioBros3-1-1-v0', all_env_ids)
+        self.assertIn('SuperMarioBros3-1-6-v0', all_env_ids)
         self.assertNotIn('SuperMarioBrosRandomStages-v0', all_env_ids)
 
     def test_task_lookup_by_env_id(self):
@@ -54,14 +58,43 @@ class ShouldExposeRegisteredTaskMetadata(TestCase):
             'SuperMarioBros2USA-7-2-v0',
             task_for_config('smb2_usa', 0, world=7, stage=2).env_id,
         )
+        self.assertEqual(
+            'SuperMarioBros3-1-4-v0',
+            task_for_config('smb3', 0, world=1, stage=4).env_id,
+        )
 
     def test_filters_are_available_for_eval_matrices(self):
         stage_tasks = all_tasks(single_stage=True)
         smb3_tasks = all_tasks(game_family='smb3')
 
-        self.assertEqual(105, len(stage_tasks))
+        self.assertEqual(108, len(stage_tasks))
         self.assertEqual(
-            ('SuperMarioBros3-v0', 'SuperMarioBros3-1-1-v0'),
+            (
+                'SuperMarioBros3-v0',
+                'SuperMarioBros3-1-1-v0',
+                'SuperMarioBros3-1-2-v0',
+                'SuperMarioBros3-1-4-v0',
+                'SuperMarioBros3-1-6-v0',
+            ),
             tuple(task.env_id for task in smb3_tasks),
         )
         self.assertRaises(ValueError, all_tasks, split='unknown')
+
+
+class ShouldExposeSuperMarioBros3StageMatrix(TestCase):
+    """Test the conservative SMB3 numbered-course catalog."""
+
+    def test_matrix_covers_numbered_courses(self):
+        stages = smb3_stage_matrix()
+
+        self.assertEqual(sum(SMB3_STAGES_PER_WORLD), len(stages))
+        self.assertEqual(
+            ('SuperMarioBros3-1-1-v0', 'SuperMarioBros3-1-2-v0'),
+            tuple(stage.env_id for stage in stages[:2]),
+        )
+        self.assertEqual('SuperMarioBros3-8-2-v0', stages[-1].env_id)
+
+    def test_validated_filter_matches_registered_entry_recipes(self):
+        stages = smb3_stage_matrix(validated=True)
+
+        self.assertEqual(SMB3_VALIDATED_STAGES, tuple(stage.target for stage in stages))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dependencies = [
     "gymnasium>=1.0.0",
-    "nes-py>=9.0.0",
+    "nes-py>=9.0.1",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Developer/CI bootstrap only. Canonical runtime metadata lives in
 # pyproject.toml.
-nes-py @ git+https://github.com/Kautenja/nes-py.git@master
+nes-py>=9.0.1
 build>=1.2.1
 PyYAML>=6.0.2


### PR DESCRIPTION
## Summary

- Fix SMB2 USA single-stage life-loss handling so episodes terminate when a life loss restarts another level before the transient transition byte can be observed.
- Decode SMB2 vertical page values as signed offsets so vertical stages do not report huge progress spikes.
- Fix SMB3 map-return bookkeeping so life-loss returns are not latched as clears, and stage clears keep a positive completion reward instead of being overwhelmed by map-time drops.
- Add frame-level regressions for SMB2 7-2 life loss, SMB2 vertical progress wrapping, SMB3 clear reward, and SMB3 full-game death-map return behavior.

## Validation

- `.venv/bin/python -m unittest gym_super_mario_bros.tests.test_smb2_env gym_super_mario_bros.tests.test_smb3_env`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m unittest discover -s gym_super_mario_bros/tests -t .`
- Scripted 96-frame smoke across all 20 SMB2 USA stages and validated SMB3 stages 1-1, 1-2, 1-4, and 1-6.
- `mario_rl.random` smoke from the sibling RL project for SMB2 USA 1-1 and SMB3 1-1.
