### PR TITLE
[codex] Bump package version to 9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This changelog is reconstructed from the repository's local tags, README,
 package metadata, and commit history.
 
-## 9.1.0 (Unreleased)
+## 9.1.0 (2026-06-10)
 
 - Environments:
   - Expanded validated Super Mario Bros. 3 single-stage entry points from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gym_super_mario_bros"
-version = "9.0.0"
+version = "9.1.0"
 description = "Super Mario Bros. for Gymnasium"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` package metadata from `9.0.0` to `9.1.0`.
- Mark the `CHANGELOG.md` 9.1.0 section with the release date now that the release has landed on `master`.

## Why

The 9.1.0 release PR was merged and tagged, but the package version metadata still reported `9.0.0`, which would produce incorrectly versioned build artifacts for the release.

## Validation

- `.venv/bin/python - <<'PY' ...` metadata assertion for `project.version == "9.1.0"`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m unittest discover -s gym_super_mario_bros/tests -t .`
